### PR TITLE
[INJIMOB-1093] remove format from vc response structure

### DIFF
--- a/Sources/VCIClient/VCIClient.swift
+++ b/Sources/VCIClient/VCIClient.swift
@@ -24,7 +24,7 @@ public class VCIClient {
             
             let request = CredentialRequestfactory.createCredentialRequest(
                 url: url,
-                credentialFormat: CredentialFormat.ldp_vc,
+                credentialFormat: issuerMeta.credentialFormat,
                 accessToken: accessToken,
                 issuer: issuerMeta,
                 proofJwt: proof

--- a/Sources/VCIClient/credentialResponse/CredentialResponseFactory.swift
+++ b/Sources/VCIClient/credentialResponse/CredentialResponseFactory.swift
@@ -2,7 +2,6 @@ import Foundation
 
 protocol CredentialResponseFactoryProtocol {
     static func createCredentialResponse(formatType: CredentialFormat, response: Data) throws -> CredentialResponse?
-    func constructResponse(response: Data) throws -> CredentialResponse?
 }
 
 extension CredentialResponseFactoryProtocol{
@@ -15,7 +14,5 @@ extension CredentialResponseFactoryProtocol{
 }
 
 class CredentialResponseFactory: CredentialResponseFactoryProtocol{
-    func constructResponse(response: Data) -> CredentialResponse? {
-        return nil
-    }
+    
 }

--- a/Sources/VCIClient/credentialResponse/types/LdpVcCredentialResponse.swift
+++ b/Sources/VCIClient/credentialResponse/types/LdpVcCredentialResponse.swift
@@ -2,11 +2,11 @@ import Foundation
 
 struct AnyCodable: Codable {
     var value: Any
-
+    
     init(_ value: Any) {
         self.value = value
     }
-
+    
     init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         if let int = try? container.decode(Int.self) {
@@ -27,7 +27,7 @@ struct AnyCodable: Codable {
             throw DownloadFailedError.decodingResponseFailed
         }
     }
-
+    
     func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         if let int = value as? Int {
@@ -51,26 +51,23 @@ struct AnyCodable: Codable {
 }
 
 struct VC: Codable, CredentialResponse {
-    var format: String
     var credential: [String: AnyCodable]
-
+    
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        format = try container.decode(String.self, forKey: .format)
         credential = try container.decode([String: AnyCodable].self, forKey: .credential)
     }
-
+    
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(format, forKey: .format)
         try container.encode(credential, forKey: .credential)
     }
-
+    
     enum CodingKeys: String, CodingKey {
         case format
         case credential
     }
-
+    
     func toJSONString() throws -> String {
         let encoder = JSONEncoder()
         encoder.outputFormatting = .prettyPrinted

--- a/Tests/VCIClientTests/VCIClientTests.swift
+++ b/Tests/VCIClientTests/VCIClientTests.swift
@@ -79,6 +79,9 @@ class VCIClientTests: XCTestCase {
           }
         }
         """.data(using: .utf8)!
+        
+        
+        
         let mockCredentialResponse = HTTPURLResponse(url: URL(string: "https://domain.net/credentials/12345-87435")!,
                                                      statusCode: 200,
                                                      httpVersion: "1.1",
@@ -97,8 +100,96 @@ class VCIClientTests: XCTestCase {
         
         do {
             let response = try await client.requestCredential(issuerMeta: issuerMeta,
-                                                               proof: JWTProof(jwt: proofJWT),
-                                                               accessToken: accessToken)
+                                                              proof: JWTProof(jwt: proofJWT),
+                                                              accessToken: accessToken)
+            XCTAssertNotNil(response)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+    
+    
+    func testRequestCredentialSuccessDraft13()async{
+        let mockCredentialResponseDataDraft13 = """
+               {
+                  "credential": {
+                   "issuer": "https://domain.net/credentials/",
+                   "issuanceDate": "2024-05-12T16:12:47.266Z",
+                   "id": "https://domain.net/credentials/858c69d7-676a-4f19-ba51-d9ed754f2935",
+                   "proof": {
+                     "proofPurpose": "assertionMethod",
+                     "created": "2024-05-12T16:12:47Z",
+                     "jws": "eyJr80435=",
+                     "verificationMethod": "https://domain.net/.well-known/ida-public-key.json",
+                     "type": "RsaSignature2018"
+                   },
+                   "credentialSubject": {
+                     "gender": [
+                       {
+                         "value": "Male",
+                         "language": "eng"
+                       }
+                     ],
+                     "phone": "9876567893",
+                     "city": [
+                       {
+                         "value": "Kenitra",
+                         "language": "eng"
+                       }
+                     ],
+                     "id": "did:jwk:eyJrdHkiOi==",
+                     "dateOfBirth": "1999/01/01",
+                     "fullName": [
+                       {
+                         "value": "santhush",
+                         "language": "eng"
+                       }
+                     ],
+                     "face": "daVqaL0H1oorC",
+                     "addressLine1": [
+                       {
+                         "value": "saravangar",
+                         "language": "eng"
+                       }
+                     ],
+                     "email": "sunthoush@gmail.com",
+                     "UIN": "9612973623"
+                   },
+                   "type": [
+                     "VerifiableCredential",
+                     "MOSIPVerifiableCredential"
+                   ],
+                   "@context": [
+                     "https://www.domain.org/2018/credentials/v1",
+                     "https://api.domain.net/.well-known/domain-context.json",
+                     {
+                       "sec": "https://w3id.org/security#"
+                     }
+                   ]
+                 }
+               }
+        """.data(using: .utf8)
+        
+        let mockCredentialResponseDraft13 = HTTPURLResponse(url: URL(string: "https://domain.net/credentials/12345-87435")!,
+                                                            statusCode: 200,
+                                                            httpVersion: "1.1",
+                                                            headerFields: ["Content-Type": "application/json"])!
+        
+        mockSession.data = mockCredentialResponseDataDraft13
+        mockSession.response = mockCredentialResponseDraft13
+        
+        let issuerMeta = IssuerMeta(credentialAudience: "https://domain.net",
+                                    credentialEndpoint: "https://domain.net/credential",
+                                    downloadTimeoutInMilliseconds: 20000,
+                                    credentialType: ["VerifiableCredential"],
+                                    credentialFormat: .ldp_vc)
+        let accessToken = "YourAccessToken"
+        let proofJWT = "YourProofJWT"
+        
+        do {
+            let response = try await client.requestCredential(issuerMeta: issuerMeta,
+                                                              proof: JWTProof(jwt: proofJWT),
+                                                              accessToken: accessToken)
             XCTAssertNotNil(response)
         } catch {
             XCTFail("Unexpected error: \(error)")
@@ -130,8 +221,8 @@ class VCIClientTests: XCTestCase {
         
         do {
             let _ = try await client.requestCredential(issuerMeta: issuerMeta,
-                                                        proof: JWTProof(jwt: proofJWT),
-                                                        accessToken: accessToken)
+                                                       proof: JWTProof(jwt: proofJWT),
+                                                       accessToken: accessToken)
             
             XCTFail("Expected an error but call succeeded")
         } catch let error as NSError {


### PR DESCRIPTION
## Changes

* Removed `format` parameter from credential response, for openid4vci draft13 compatibility.
* Refactoring and formatting