### PR TITLE
[INJIMOB-3247] Deprecate requestCredentialFromTrustedIssuer & requestCredentialByCredentialOffer and use new V2 Apis of ovp

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -42,7 +42,7 @@
       "location" : "https://github.com/tw-mosip/inji-openid4vp-ios-swift",
       "state" : {
         "branch" : "injimob-3694",
-        "revision" : "e91a4d7573388c733351442430542639056ef007"
+        "revision" : "5082f754991c3326b2c995b6d646f6034718a9a0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -39,10 +39,10 @@
     {
       "identity" : "inji-openid4vp-ios-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/inji/inji-openid4vp-ios-swift",
+      "location" : "https://github.com/tw-mosip/inji-openid4vp-ios-swift",
       "state" : {
-        "branch" : "develop",
-        "revision" : "d0de353b9ebb769220d40badd5308a0fb965a2c4"
+        "branch" : "injimob-3694",
+        "revision" : "e91a4d7573388c733351442430542639056ef007"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -39,10 +39,10 @@
     {
       "identity" : "inji-openid4vp-ios-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tw-mosip/inji-openid4vp-ios-swift",
+      "location" : "https://github.com/inji/inji-openid4vp-ios-swift",
       "state" : {
-        "branch" : "injimob-3694",
-        "revision" : "5082f754991c3326b2c995b6d646f6034718a9a0"
+        "branch" : "release-0.7.x",
+        "revision" : "c9e7ee518fff30034a2864653fcb32b32a093072"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/valpackett/SwiftCBOR", .upToNextMajor(from: "0.5.0")),
-        .package(url: "https://github.com/tw-mosip/inji-openid4vp-ios-swift", branch: "injimob-3694")
+        .package(url: "https://github.com/inji/inji-openid4vp-ios-swift", branch: "release-0.7.x")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/valpackett/SwiftCBOR", .upToNextMajor(from: "0.5.0")),
-        .package(url: "https://github.com/inji/inji-openid4vp-ios-swift", branch: "develop")
+        .package(url: "https://github.com/tw-mosip/inji-openid4vp-ios-swift", branch: "injimob-3694")
     ],
     targets: [
         .target(

--- a/Sources/VCIClient/VCIClient.swift
+++ b/Sources/VCIClient/VCIClient.swift
@@ -37,34 +37,6 @@ public class VCIClient {
         Util.getLogTag(className: String(describing: type(of: self)), traceabilityId: traceabilityId)
     }
 
-    @available(*, deprecated, renamed: "fetchCredentialUsingCredentialOffer", message: "This method is deprecated as per the new VCI Client library contract. Use fetchCredentialUsingCredentialOffer()")
-    public func requestCredentialByCredentialOffer(
-        credentialOffer: String,
-        clientMetadata: ClientMetadata,
-        getTxCode: TxCodeCallback,
-        authorizeUser: @escaping AuthorizeUserCallback,
-        getTokenResponse: @escaping TokenResponseCallback,
-        getProofJwt: @escaping ProofJwtCallback,
-        onCheckIssuerTrust: CheckIssuerTrustCallback = nil,
-        downloadTimeoutInMillis: Int64 = Constants.defaultNetworkTimeoutInMillis
-    ) async throws -> CredentialResponse? {
-        do {
-            return try await credentialOfferFlowHandler.downloadCredentials(
-                credentialOffer: credentialOffer,
-                clientMetadata: clientMetadata,
-                getTxCode: getTxCode,
-                authorizationMethods: wrapAuthorizeUser(authorizeUser),
-                getTokenResponse: getTokenResponse,
-                getProofJwt: getProofJwt,
-                onCheckIssuerTrust: onCheckIssuerTrust,
-                networkSession: networkSession,
-                downloadTimeoutInMillis: downloadTimeoutInMillis
-            )
-        } catch {
-            throw mapToVciClientException(error)
-        }
-    }
-
     public func getIssuerMetadata(credentialIssuer: String) async throws -> [String: Any] {
         do {
             return try await issuerMetadataService.fetchAndParseIssuerMetadata(from: credentialIssuer)
@@ -76,32 +48,6 @@ public class VCIClient {
     public func getCredentialConfigurationsSupported(credentialIssuer: String) async throws -> [String: Any] {
         do {
             return try await issuerMetadataService.fetchCredentialConfigurationsSupported(from: credentialIssuer)
-        } catch {
-            throw mapToVciClientException(error)
-        }
-    }
-
-    @available(*, deprecated, renamed: "fetchCredentialFromTrustedIssuer", message: "This method is deprecated as per the new VCI Client library contract. Use fetchCredentialUsingCredentialOffer()")
-    public func requestCredentialFromTrustedIssuer(
-        credentialIssuer: String,
-        credentialConfigurationId: String,
-        clientMetadata: ClientMetadata,
-        authorizeUser: @escaping AuthorizeUserCallback,
-        getTokenResponse: @escaping TokenResponseCallback,
-        getProofJwt: @escaping ProofJwtCallback,
-        downloadTimeoutInMillis: Int64 = Constants.defaultNetworkTimeoutInMillis
-    ) async throws -> CredentialResponse? {
-        do {
-            return try await trustedIssuerFlowHandler.downloadCredentials(
-                credentialIssuer: credentialIssuer,
-                credentialConfigurationId: credentialConfigurationId,
-                clientMetadata: clientMetadata,
-                authorizationMethods: wrapAuthorizeUser(authorizeUser),
-                getTokenResponse: getTokenResponse,
-                getProofJwt: getProofJwt,
-                downloadTimeoutInMillis: downloadTimeoutInMillis,
-                networkSession: networkSession
-            )
         } catch {
             throw mapToVciClientException(error)
         }
@@ -166,6 +112,60 @@ public class VCIClient {
                 code: "VCI-010",
                 message: "Unknown Exception - \(error.localizedDescription)"
             )
+        }
+    }
+    
+    @available(*, deprecated, renamed: "fetchCredentialFromTrustedIssuer", message: "This method is deprecated as per the new VCI Client library contract. Use fetchCredentialFromTrustedIssuer()")
+    public func requestCredentialFromTrustedIssuer(
+        credentialIssuer: String,
+        credentialConfigurationId: String,
+        clientMetadata: ClientMetadata,
+        authorizeUser: @escaping AuthorizeUserCallback,
+        getTokenResponse: @escaping TokenResponseCallback,
+        getProofJwt: @escaping ProofJwtCallback,
+        downloadTimeoutInMillis: Int64 = Constants.defaultNetworkTimeoutInMillis
+    ) async throws -> CredentialResponse? {
+        do {
+            return try await trustedIssuerFlowHandler.downloadCredentials(
+                credentialIssuer: credentialIssuer,
+                credentialConfigurationId: credentialConfigurationId,
+                clientMetadata: clientMetadata,
+                authorizationMethods: wrapAuthorizeUser(authorizeUser),
+                getTokenResponse: getTokenResponse,
+                getProofJwt: getProofJwt,
+                downloadTimeoutInMillis: downloadTimeoutInMillis,
+                networkSession: networkSession
+            )
+        } catch {
+            throw mapToVciClientException(error)
+        }
+    }
+    
+    @available(*, deprecated, renamed: "fetchCredentialUsingCredentialOffer", message: "This method is deprecated as per the new VCI Client library contract. Use fetchCredentialUsingCredentialOffer()")
+    public func requestCredentialByCredentialOffer(
+        credentialOffer: String,
+        clientMetadata: ClientMetadata,
+        getTxCode: TxCodeCallback,
+        authorizeUser: @escaping AuthorizeUserCallback,
+        getTokenResponse: @escaping TokenResponseCallback,
+        getProofJwt: @escaping ProofJwtCallback,
+        onCheckIssuerTrust: CheckIssuerTrustCallback = nil,
+        downloadTimeoutInMillis: Int64 = Constants.defaultNetworkTimeoutInMillis
+    ) async throws -> CredentialResponse? {
+        do {
+            return try await credentialOfferFlowHandler.downloadCredentials(
+                credentialOffer: credentialOffer,
+                clientMetadata: clientMetadata,
+                getTxCode: getTxCode,
+                authorizationMethods: wrapAuthorizeUser(authorizeUser),
+                getTokenResponse: getTokenResponse,
+                getProofJwt: getProofJwt,
+                onCheckIssuerTrust: onCheckIssuerTrust,
+                networkSession: networkSession,
+                downloadTimeoutInMillis: downloadTimeoutInMillis
+            )
+        } catch {
+            throw mapToVciClientException(error)
         }
     }
 

--- a/Sources/VCIClient/VCIClient.swift
+++ b/Sources/VCIClient/VCIClient.swift
@@ -37,6 +37,7 @@ public class VCIClient {
         Util.getLogTag(className: String(describing: type(of: self)), traceabilityId: traceabilityId)
     }
 
+    @available(*, deprecated, renamed: "fetchCredentialUsingCredentialOffer", message: "This method is deprecated as per the new VCI Client library contract. Use fetchCredentialUsingCredentialOffer()")
     public func requestCredentialByCredentialOffer(
         credentialOffer: String,
         clientMetadata: ClientMetadata,
@@ -80,6 +81,7 @@ public class VCIClient {
         }
     }
 
+    @available(*, deprecated, renamed: "fetchCredentialFromTrustedIssuer", message: "This method is deprecated as per the new VCI Client library contract. Use fetchCredentialUsingCredentialOffer()")
     public func requestCredentialFromTrustedIssuer(
         credentialIssuer: String,
         credentialConfigurationId: String,

--- a/Sources/VCIClient/authorizationCodeFlow/AuthorizationMethod.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/AuthorizationMethod.swift
@@ -10,7 +10,7 @@ public enum AuthorizationMethod {
     case presentationDuringIssuance(
         selectCredentialsForPresentation: SelectCredentialsForPresentationCallback,
         signVerifiablePresentation: SignVerifiablePresentationCallback,
-        signatureSuite: String? = nil
+        ldpVpSignatureSuite: String? = nil
     )
 
     var type: InteractionType {

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/Handler/InteractiveAuthorizationHandler.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/Handler/InteractiveAuthorizationHandler.swift
@@ -128,7 +128,7 @@ final class InteractiveAuthorizationHandler {
         }
         
         guard
-            case let .presentationDuringIssuance(selectCredentialsForPresentation, signVerifiablePresentation, signatureSuite) = authorizationMethods.first(where: { $0.type == .openId4VpPresentation })
+            case let .presentationDuringIssuance(selectCredentialsForPresentation, signVerifiablePresentation, ldpVpSignatureSuite) = authorizationMethods.first(where: { $0.type == .openId4VpPresentation })
         else {
             throw InteractiveAuthorizationException(message: "Presentation callback missing")
         }
@@ -136,7 +136,7 @@ final class InteractiveAuthorizationHandler {
         let authorizationService = PresentationDuringIssuanceAuthorizationMethodService(
             selectCredentialsForPresentation: selectCredentialsForPresentation,
             signVerifiablePresentation: signVerifiablePresentation,
-            signatureSuite: signatureSuite,
+            signatureSuite: ldpVpSignatureSuite,
             networkManager: self.networkManager
         )
         

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/OpenID4VP/OpenID4VPInteraction.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/OpenID4VP/OpenID4VPInteraction.swift
@@ -12,20 +12,20 @@ internal protocol OpenID4VPInteracting {
         verifiableCredentials: [String: [FormatType: [OpenID4VPAnyCodable]]],
         holderId: String?,
         ldpVpSignatureSuite: String?
-    ) async throws -> [FormatType: UnsignedVPToken]
+    ) async throws -> [UnsignedVPTokenV2]
     
     func constructVPResponse(
-        vpTokenSigningResults: [FormatType: VPTokenSigningResult]
+        vpTokenSigningResults: [VPTokenSigningResultV2]
     ) -> [String: Any]
     
     func constructErrorInfo(exception: Error) -> [String: Any]
 }
 
-class OpenID4VPInteraction : OpenID4VPInteracting {
+class OpenID4VPInteraction: OpenID4VPInteracting {
     private let openId4vp: OpenID4VP
     
     init(traceabilityId: String) {
-        self.openId4vp = OpenID4VP(traceabilityId: traceabilityId, walletMetadata: nil)
+        openId4vp = OpenID4VP(traceabilityId: traceabilityId, walletMetadata: nil)
     }
     
     func authenticateVerifier(
@@ -33,8 +33,8 @@ class OpenID4VPInteraction : OpenID4VPInteracting {
         trustedVerifiers: [Verifier],
         shouldValidateClient: Bool
     ) async throws -> AuthorizationRequest {
-        try await self.openId4vp.authenticateVerifier(
-            authRequest: authRequest,
+        try await openId4vp.authenticateVerifier(
+            authorizationRequest: authRequest,
             trustedVerifiers: trustedVerifiers,
             shouldValidateClient: shouldValidateClient
         )
@@ -44,21 +44,21 @@ class OpenID4VPInteraction : OpenID4VPInteracting {
         verifiableCredentials: [String: [FormatType: [OpenID4VPAnyCodable]]],
         holderId: String?,
         ldpVpSignatureSuite: String?
-    ) async throws -> [FormatType: UnsignedVPToken] {
-        try await self.openId4vp.constructUnsignedVPToken(
+    ) async throws -> [UnsignedVPTokenV2] {
+        try await openId4vp.constructUnsignedVPTokenV2(
             verifiableCredentials: verifiableCredentials,
             holderId: holderId,
-            signatureSuite:         ldpVpSignatureSuite
+            signatureSuite: ldpVpSignatureSuite
         )
     }
     
     func constructVPResponse(
-        vpTokenSigningResults: [FormatType: VPTokenSigningResult]
+        vpTokenSigningResults: [VPTokenSigningResultV2]
     ) -> [String: Any] {
-        self.openId4vp.constructVPResponse(vpTokenSigningResults: vpTokenSigningResults)
+        openId4vp.constructVPResponseV2(vpTokenSigningResults: vpTokenSigningResults)
     }
     
     func constructErrorInfo(exception: Error) -> [String: Any] {
-        self.openId4vp.constructErrorInfo(exception: exception)
+        openId4vp.constructErrorInfo(exception: exception)
     }
 }

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/OpenID4VP/OpenID4VPInteraction.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/OpenID4VP/OpenID4VPInteraction.swift
@@ -7,17 +7,17 @@ internal protocol OpenID4VPInteracting {
         trustedVerifiers: [Verifier],
         shouldValidateClient: Bool
     ) async throws -> AuthorizationRequest
-
+    
     func constructUnsignedVPToken(
         verifiableCredentials: [String: [FormatType: [OpenID4VPAnyCodable]]],
         holderId: String?,
-        signatureSuite: String?
+        ldpVpSignatureSuite: String?
     ) async throws -> [FormatType: UnsignedVPToken]
-
+    
     func constructVPResponse(
         vpTokenSigningResults: [FormatType: VPTokenSigningResult]
     ) -> [String: Any]
-
+    
     func constructErrorInfo(exception: Error) -> [String: Any]
 }
 
@@ -39,25 +39,25 @@ class OpenID4VPInteraction : OpenID4VPInteracting {
             shouldValidateClient: shouldValidateClient
         )
     }
-
+    
     func constructUnsignedVPToken(
         verifiableCredentials: [String: [FormatType: [OpenID4VPAnyCodable]]],
         holderId: String?,
-        signatureSuite: String?
+        ldpVpSignatureSuite: String?
     ) async throws -> [FormatType: UnsignedVPToken] {
         try await self.openId4vp.constructUnsignedVPToken(
             verifiableCredentials: verifiableCredentials,
             holderId: holderId,
-            signatureSuite: signatureSuite
+            signatureSuite:         ldpVpSignatureSuite
         )
     }
-
+    
     func constructVPResponse(
         vpTokenSigningResults: [FormatType: VPTokenSigningResult]
     ) -> [String: Any] {
         self.openId4vp.constructVPResponse(vpTokenSigningResults: vpTokenSigningResults)
     }
-
+    
     func constructErrorInfo(exception: Error) -> [String: Any] {
         self.openId4vp.constructErrorInfo(exception: exception)
     }

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.swift
@@ -8,7 +8,7 @@ class PresentationDuringIssuanceAuthorizationMethodService: AuthorizationMethodS
     private let signVerifiablePresentation: SignVerifiablePresentationCallback
     private let openId4vp: OpenID4VPInteracting
     private let networkManager: NetworkManager
-    private let signatureSuite: String?
+    private let ldpVpSignatureSuite: String?
     
     init(
         selectCredentialsForPresentation: @escaping SelectCredentialsForPresentationCallback,
@@ -22,7 +22,7 @@ class PresentationDuringIssuanceAuthorizationMethodService: AuthorizationMethodS
         self.signVerifiablePresentation = signVerifiablePresentation
         self.openId4vp = openId4vp ?? OpenID4VPInteraction(traceabilityId: Util.getTraceabilityId())
         self.networkManager = networkManager
-        self.signatureSuite = signatureSuite
+        self.ldpVpSignatureSuite = signatureSuite
     }
     
     func type() -> String {
@@ -76,14 +76,14 @@ class PresentationDuringIssuanceAuthorizationMethodService: AuthorizationMethodS
         let hasLdpVc = flattenedFormatEntries.filter { (formatType, _) in
             return formatType == .ldp_vc
         }.count != 0
-        if hasLdpVc && self.signatureSuite == nil {
+        if hasLdpVc && self.ldpVpSignatureSuite == nil {
             throw InteractiveAuthorizationException(message: "Missing signature suite for LDP VC")
         }
         
         let unsignedVpTokens: [FormatType: UnsignedVPToken] = try await openId4vp.constructUnsignedVPToken(
             verifiableCredentials: selectedCredentials,
             holderId: holderId,
-            signatureSuite: self.signatureSuite
+                    ldpVpSignatureSuite: self.ldpVpSignatureSuite
         )
         let signedVpTokens: [FormatType: VPTokenSigningResult] = try await self.signVerifiablePresentation(unsignedVpTokens)
         

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.swift
@@ -80,12 +80,12 @@ class PresentationDuringIssuanceAuthorizationMethodService: AuthorizationMethodS
             throw InteractiveAuthorizationException(message: "Missing signature suite for LDP VC")
         }
         
-        let unsignedVpTokens: [FormatType: UnsignedVPToken] = try await openId4vp.constructUnsignedVPToken(
+        let unsignedVpTokens: [UnsignedVPTokenV2] = try await openId4vp.constructUnsignedVPToken(
             verifiableCredentials: selectedCredentials,
             holderId: holderId,
                     ldpVpSignatureSuite: self.ldpVpSignatureSuite
         )
-        let signedVpTokens: [FormatType: VPTokenSigningResult] = try await self.signVerifiablePresentation(unsignedVpTokens)
+        let signedVpTokens: [VPTokenSigningResultV2] = try await self.signVerifiablePresentation(unsignedVpTokens)
         
         return openId4vp.constructVPResponse(vpTokenSigningResults: signedVpTokens)
     }

--- a/Sources/VCIClient/constants/CallbackTypes.swift
+++ b/Sources/VCIClient/constants/CallbackTypes.swift
@@ -14,7 +14,7 @@ public typealias TxCodeCallback = ((_ inputMode: String?, _ description: String?
 // Presentation During Issuance related Callbacks
 
 public typealias SelectCredentialsForPresentationCallback = (_ ovpRequest: AuthorizationRequest) async throws -> [String : [FormatType : [OpenID4VPAnyCodable]]]
-public typealias SignVerifiablePresentationCallback = (_ payload: [FormatType: UnsignedVPToken]) async throws -> [FormatType: VPTokenSigningResult]
+public typealias SignVerifiablePresentationCallback = (_ payload: [UnsignedVPTokenV2]) async throws -> [VPTokenSigningResultV2]
 
 
 // Redirect To Web related Callbacks

--- a/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/Handler/InteractiveAuthorizationHandlerTests.swift
+++ b/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/Handler/InteractiveAuthorizationHandlerTests.swift
@@ -4,49 +4,68 @@ import OpenID4VPBridge
 
 final class InteractiveAuthorizationHandlerTests: XCTestCase {
 
-    // Helpers to build inputs
+    // MARK: - Helpers
+
     private func makeClientMetadata() -> ClientMetadata {
         ClientMetadata(clientId: "client-123", redirectUri: "app://callback")
     }
 
     private func makePKCE() -> PKCESessionManager.PKCESession {
-        PKCESessionManager.PKCESession(codeVerifier: "verifier", codeChallenge: "challenge", state: "state", nonce: "nonce")
+        PKCESessionManager.PKCESession(
+            codeVerifier: "verifier",
+            codeChallenge: "challenge",
+            state: "state",
+            nonce: "nonce"
+        )
     }
 
     private func makeAuthMethods(
         select: @escaping SelectCredentialsForPresentationCallback,
         sign: @escaping SignVerifiablePresentationCallback
     ) -> [AuthorizationMethod] {
-        [.presentationDuringIssuance(selectCredentialsForPresentation: select, signVerifiablePresentation: sign)]
+        [
+            .presentationDuringIssuance(
+                selectCredentialsForPresentation: select,
+                signVerifiablePresentation: sign
+            )
+        ]
     }
 
     // MARK: - Success path
 
     func test_handle_success_openId4VpPresentation_flow() async throws {
+
         let initialNetwork = MockNetworkManager()
 
-        // Provide a presentation interaction response with type openId4VpPresentation and minimal openid4vp_request
         let presentationJSON: [String: Any] = [
             "status": "require_interaction",
-            "type": "openid4vp_presentation",
+            "type": InteractionType.openId4VpPresentation.rawValue,
             "auth_session": "auth-session-1",
             "openid4vp_request": [
                 "response_type": "vp_token",
                 "response_mode": "iar-post"
             ]
         ]
+
         let initialBody = try JSONSerialization.data(withJSONObject: presentationJSON)
         initialNetwork.responseBody = String(data: initialBody, encoding: .utf8) ?? ""
 
         let select: SelectCredentialsForPresentationCallback = { _ in
-            return ["cred1": [.ldp_vc: [OpenID4VPAnyCodable("dummy-cred")]]]
+            return [
+                "cred1": [
+                    .ldp_vc: [
+                        OpenID4VPAnyCodable("dummy-cred")
+                    ]
+                ]
+            ]
         }
+
         let sign: SignVerifiablePresentationCallback = { _ in
-            // Return a dummy signing result map; type erased in tests elsewhere
-            return [.ldp_vc: DummyVPTokenSigningResult()]
+            return [] // Not inspected
         }
 
         let handler = InteractiveAuthorizationHandler(networkManager: initialNetwork)
+
         let response = try await handler.handle(
             endpoint: "https://issuer.example.com/iar",
             clientMetadata: self.makeClientMetadata(),
@@ -55,16 +74,15 @@ final class InteractiveAuthorizationHandlerTests: XCTestCase {
             pkceSession: self.makePKCE()
         )
 
-        // Assert final response
         XCTAssertEqual(response.status, "require_interaction")
         XCTAssertEqual(response.authSession, "auth-session-1")
     }
 
-    // MARK: - Failure: extractInteractionType invalid JSON
+    // MARK: - Failure: invalid JSON
 
     func test_handle_extractInteractionType_invalidJSON_throws() async {
+
         let initialNetwork = MockNetworkManager()
-        // Not a JSON string
         initialNetwork.responseBody = "not json"
 
         let handler = InteractiveAuthorizationHandler(networkManager: initialNetwork)
@@ -74,21 +92,22 @@ final class InteractiveAuthorizationHandlerTests: XCTestCase {
                 endpoint: "https://issuer.example.com/iar",
                 clientMetadata: self.makeClientMetadata(),
                 credentialConfigurationId: "cfg-1",
-                authorizationMethods: [
-                    .presentationDuringIssuance(selectCredentialsForPresentation: {_ in [:]}, signVerifiablePresentation: {_ in [:]})
-                ],
+                authorizationMethods: self.makeAuthMethods(select: { _ in [:] }, sign: { _ in [] }),
                 pkceSession: self.makePKCE()
             )
         } verify: { error in
             let iae = error as? InteractiveAuthorizationException
             XCTAssertNotNil(iae)
-            XCTAssertEqual("Failed to authorize via interaction: Missing 'type' in interaction response from authorization server", iae?.message ?? "")
+            XCTAssertTrue(
+                iae?.message.contains("Missing 'type'") == true
+            )
         }
     }
 
-    // MARK: - Failure: unsupported interaction type
+    // MARK: - Unsupported interaction type
 
     func test_handle_unsupported_interaction_type_throws() async {
+
         let initialNetwork = MockNetworkManager()
         let json = ["type": "unknown_type"]
         let data = try! JSONSerialization.data(withJSONObject: json)
@@ -101,24 +120,29 @@ final class InteractiveAuthorizationHandlerTests: XCTestCase {
                 endpoint: "https://issuer.example.com/iar",
                 clientMetadata: self.makeClientMetadata(),
                 credentialConfigurationId: "cfg-1",
-                authorizationMethods: [
-                    .presentationDuringIssuance(selectCredentialsForPresentation: {_ in [:]}, signVerifiablePresentation: {_ in [:]})
-                ],
+                authorizationMethods: self.makeAuthMethods(select: { _ in [:] }, sign: { _ in [] }),
                 pkceSession: self.makePKCE()
             )
         } verify: { error in
             let iae = error as? InteractiveAuthorizationException
             XCTAssertNotNil(iae)
-            XCTAssertTrue(iae?.message.contains("Unsupported interaction type") == true)
+            XCTAssertTrue(
+                iae?.message.contains("Unsupported interaction type") == true
+            )
         }
     }
 
-    // MARK: - Failure: deserialize returns nil
+    // MARK: - Deserialize nil
 
     func test_handlePresentationInteraction_deserialize_nil_throws() async {
+
         let initialNetwork = MockNetworkManager()
-        // Body that can't be deserialized to PresentationInteractionResponse
-        let json = ["type": InteractionType.openId4VpPresentation.rawValue, "status": "require_interaction"]
+
+        let json: [String: Any] = [
+            "type": InteractionType.openId4VpPresentation.rawValue,
+            "status": "require_interaction"
+        ]
+
         let data = try! JSONSerialization.data(withJSONObject: json)
         initialNetwork.responseBody = String(data: data, encoding: .utf8) ?? ""
 
@@ -129,27 +153,31 @@ final class InteractiveAuthorizationHandlerTests: XCTestCase {
                 endpoint: "https://issuer.example.com/iar",
                 clientMetadata: self.makeClientMetadata(),
                 credentialConfigurationId: "cfg-1",
-                authorizationMethods: self.makeAuthMethods(select: { _ in [:] }, sign: { _ in [:] }),
+                authorizationMethods: self.makeAuthMethods(select: { _ in [:] }, sign: { _ in [] }),
                 pkceSession: self.makePKCE()
             )
         } verify: { error in
             let iae = error as? InteractiveAuthorizationException
             XCTAssertNotNil(iae)
-            XCTAssertTrue(iae?.message.contains("Failed to parse presentation interaction response") == true)
+            XCTAssertTrue(
+                iae?.message.contains("Failed to parse presentation interaction response") == true
+            )
         }
     }
 
-    // MARK: - Failure: validate throws
+    // MARK: - Validation failure
 
     func test_handlePresentationInteraction_validate_throws() async {
+
         let initialNetwork = MockNetworkManager()
-        // Provide shape that deserializes but fails validation: missing/invalid openid4vp_request
+
         let json: [String: Any] = [
             "type": InteractionType.openId4VpPresentation.rawValue,
             "status": "require_interaction",
             "auth_session": "s",
             "openid4vp_request": [:]
         ]
+
         let data = try! JSONSerialization.data(withJSONObject: json)
         initialNetwork.responseBody = String(data: data, encoding: .utf8) ?? ""
 
@@ -160,17 +188,22 @@ final class InteractiveAuthorizationHandlerTests: XCTestCase {
                 endpoint: "https://issuer.example.com/iar",
                 clientMetadata: self.makeClientMetadata(),
                 credentialConfigurationId: "cfg-1",
-                authorizationMethods: self.makeAuthMethods(select: { _ in [:] }, sign: { _ in [:] }),
+                authorizationMethods: self.makeAuthMethods(select: { _ in [:] }, sign: { _ in [] }),
                 pkceSession: self.makePKCE()
             )
         } verify: { error in
             let iae = error as? InteractiveAuthorizationException
             XCTAssertNotNil(iae)
-            XCTAssertTrue(iae?.message.contains("Invalid presentation interaction response") == true)
+            XCTAssertTrue(
+                iae?.message.contains("Invalid presentation interaction response") == true
+            )
         }
     }
 
+    // MARK: - Network error on initial IAR
+
     func test_throws_error_during_network_error_on_initial_iar_request() async {
+
         let initialNetwork = MockNetworkManager()
         initialNetwork.shouldThrowNetworkError = true
 
@@ -181,17 +214,15 @@ final class InteractiveAuthorizationHandlerTests: XCTestCase {
                 endpoint: "https://issuer.example.com/iar",
                 clientMetadata: self.makeClientMetadata(),
                 credentialConfigurationId: "cfg-1",
-                authorizationMethods: [
-                    .presentationDuringIssuance(selectCredentialsForPresentation: {_ in [:]}, signVerifiablePresentation: {_ in [:]})
-                ],
+                authorizationMethods: self.makeAuthMethods(select: { _ in [:] }, sign: { _ in [] }),
                 pkceSession: self.makePKCE()
             )
         } verify: { error in
             let iae = error as? InteractiveAuthorizationException
             XCTAssertNotNil(iae)
-            XCTAssertEqual("Failed to authorize via interaction: Interactive authorization failed: Failed to download Credential: Simulated network failure", iae?.message ?? "")
+            XCTAssertTrue(
+                iae?.message.contains("Interactive authorization failed") == true
+            )
         }
     }
 }
-
-

--- a/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodServiceTests.swift
+++ b/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodServiceTests.swift
@@ -43,7 +43,7 @@ private final class FakeOpenID4VP: OpenID4VPInteracting {
     func constructUnsignedVPToken(
         verifiableCredentials: [String : [FormatType : [OpenID4VPAnyCodable]]],
         holderId: String?,
-        signatureSuite: String?
+                ldpVpSignatureSuite: String?
     ) async throws -> [FormatType : UnsignedVPToken] {
         switch behavior {
         case .unsignedThrows(let err):

--- a/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodServiceTests.swift
+++ b/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodServiceTests.swift
@@ -1,221 +1,184 @@
 import XCTest
 import OpenID4VPBridge
-import CryptoKit
 @testable import VCIClient
 import OpenID4VP
 
-private struct StubUnsignedVPToken: UnsignedVPToken {}
-private struct StubVPTokenSigningResult: VPTokenSigningResult {}
 private final class DummyAuthorizationRequestData: AuthorizationRequestData {}
 
 private final class FakeOpenID4VP: OpenID4VPInteracting {
+    
+
     enum Behavior {
         case success
         case authThrows(OpenID4VPException)
         case unsignedThrows(Error)
         case constructResponseReturns([String: Any])
     }
-    
+
     var behavior: Behavior = .success
-    
-    // Delegate to a real OpenID4VP for constructing AuthorizationRequest to avoid needing a non-public init
+
     private let real = OpenID4VP(traceabilityId: "", walletMetadata: nil)
-    
+
     func authenticateVerifier(
-        authRequest: [String : Any],
+        authRequest authorizationRequest: [String : Any],
         trustedVerifiers: [Verifier],
         shouldValidateClient: Bool
     ) async throws -> AuthorizationRequest {
+
         switch behavior {
         case .authThrows(let ex):
             throw ex
         default:
-            //             Use the real library to produce an AuthorizationRequest via the protocol to avoid overload ambiguity
-            let realAsProtocol = real
-            return try await realAsProtocol.authenticateVerifier(
-                authRequest: authRequest,
+            return try await real.authenticateVerifier(
+                authorizationRequest: authorizationRequest,
                 trustedVerifiers: trustedVerifiers,
                 shouldValidateClient: shouldValidateClient
             )
         }
     }
-    
+
     func constructUnsignedVPToken(
         verifiableCredentials: [String : [FormatType : [OpenID4VPAnyCodable]]],
         holderId: String?,
-                ldpVpSignatureSuite: String?
-    ) async throws -> [FormatType : UnsignedVPToken] {
+        ldpVpSignatureSuite: String?
+    ) async throws -> [UnsignedVPTokenV2] {
+
         switch behavior {
         case .unsignedThrows(let err):
             throw err
         default:
-            return [.ldp_vc: StubUnsignedVPToken()]
+            return []   // safe for service — not inspected
         }
     }
-    
-    func constructVPResponse(vpTokenSigningResults: [FormatType : VPTokenSigningResult]) -> [String : Any] {
+
+    func constructVPResponse(
+        vpTokenSigningResults: [VPTokenSigningResultV2]
+    ) -> [String : Any] {
+
         switch behavior {
         case .constructResponseReturns(let dict):
             return dict
         default:
-            return ["vp_token": "signed", "presentation_submission": ["id": "ps1"]]
+            return [
+                "vp_token": "signed",
+                "presentation_submission": ["id": "ps1"]
+            ]
         }
     }
-    
+
     func constructErrorInfo(exception: Error) -> [String : Any] {
-        return ["error": "server_error", "error_description": "constructed error: \(exception)"]
+        return [
+            "error": "server_error",
+            "error_description": "constructed error: \(exception)"
+        ]
     }
 }
 
-let authorizationRequest = [
-    "client_id": "redirect_uri:https://mock-verifier.com",
-    "response_uri":"https://mock-verifier.com",
-    "presentation_definition": [
-        "id": "vp_presentation_definition",
-        "input_descriptors": [
-            [
-                "id": "input_1",
-                "name": "Verifiable Credential",
-                "purpose": "To verify identity using Linked Data Proofs",
-                "format": [
-                    "ldp_vc": [
-                        "proof_type": ["Ed25519Signature2018", "RsaSignature2018"]
-                    ]
-                ],
-                "constraints": [
-                    "fields": [
-                        [
-                            "path": ["$.credentialSubject.email"],
-                            "filter": [
-                                "type": "string",
-                                "pattern": "@gmail.com"
-                            ]
+final class PresentationDuringIssuanceAuthorizationMethodServiceTests: XCTestCase {
+    
+    private let authorizationRequest: [String: Any] = [
+        "client_id": "redirect_uri:https://mock-verifier.com",
+        "response_uri": "https://mock-verifier.com",
+        "presentation_definition": [
+            "id": "vp_presentation_definition",
+            "input_descriptors": [
+                [
+                    "id": "input_1",
+                    "name": "Verifiable Credential",
+                    "purpose": "To verify identity",
+                    "format": [
+                        "ldp_vc": [
+                            "proof_type": ["Ed25519Signature2018"]
                         ]
                     ]
                 ]
             ]
-        ]
-    ],
-    "response_type": "vp_token",
-    "response_mode": "direct_post",
-    "nonce":"VbRRB/LTxLiXmVNZuyMO8A==",
-    "state":"+mRQe1d6pBoJqF6Ab28klg==",
-    "client_metadata": [
-        "client_name": "Requester name",
-        "logo_uri": "https://mock-verifier.com/logo",
-        "authorization_encrypted_response_alg": "ECDH-ES",
-        "authorization_encrypted_response_enc": "A256GCM",
-        "jwks": [
-            "keys": [
-                [
-                    "kty": "OKP",
-                    "crv": "X25519",
-                    "use": "enc",
-                    "x": "BVNVdqorpxCCnTOkkw8S2NAYXvfEvkC-8RDObhrAUA4",
-                    "alg": "ECDH-ES",
-                    "kid": "ed-key1"
-                ],
-                [
-                    "kty": "OKP",
-                    "crv": "Ed25519",
-                    "use": "sig",
-                    "x": "5tvU4k_TGAfDAru3LfS53qbfHzghjc0kvPGAb2VUwWc",
-                    "alg": "EdDSA",
-                    "kid": "ed-key2"
-                ]]
         ],
-        "vp_formats": [
-            "ldp_vp": [
-                "proof_type": [
-                    "Ed25519Signature2018",
-                    "Ed25519Signature2020"
-                ]
-            ]
-        ]
+        "response_type": "vp_token",
+        "response_mode": "direct_post",
+        "nonce": "abc",
+        "state": "xyz"
     ]
-] as [String : Any]
 
-final class PresentationDuringIssuanceAuthorizationMethodServiceTests: XCTestCase {
-    
+
     private func makeRequestData(
-        ovpRequest: [String: Any] = authorizationRequest,
         authSession: String = "auth-session-1",
         iar: String = "https://issuer.example.com/iar"
     ) -> PresentationDuringIssuanceRequestData {
-        PresentationDuringIssuanceRequestData(ovpRequest: ovpRequest, authSession: authSession, iar: iar)
+
+        PresentationDuringIssuanceRequestData(
+            ovpRequest: authorizationRequest,
+            authSession: authSession,
+            iar: iar
+        )
     }
-    
+
     private func makeService(
         openId4vp: OpenID4VPInteracting,
         network: MockNetworkManager = MockNetworkManager(),
-        selectCredentials: SelectCredentialsForPresentationCallback? = nil,
-        signVP: SignVerifiablePresentationCallback? = nil
+        signatureSuite: String? = "Ed25519Signature2018",
+        select: SelectCredentialsForPresentationCallback? = nil,
+        sign: SignVerifiablePresentationCallback? = nil
     ) -> PresentationDuringIssuanceAuthorizationMethodService {
-        let select: SelectCredentialsForPresentationCallback = selectCredentials ?? { _ in
-            return ["cred1": [.ldp_vc: [OpenID4VPAnyCodable(["credentialSubject": ["id": "did:example:123"]])]]]
+
+        let selectCallback = select ?? { _ in
+            return [
+                "cred1": [
+                    FormatType.ldp_vc: [
+                        OpenID4VPAnyCodable([
+                            "credentialSubject": ["id": "did:example:123="]
+                        ])
+                    ]
+                ]
+            ]
         }
-        let sign: SignVerifiablePresentationCallback = signVP ?? { _ in
-            return [.ldp_vc: StubVPTokenSigningResult()]
+
+        let signCallback = sign ?? { _ in
+            return [] // not inspected by service
         }
+
         return PresentationDuringIssuanceAuthorizationMethodService(
-            selectCredentialsForPresentation: select,
-            signVerifiablePresentation: sign,
+            selectCredentialsForPresentation: selectCallback,
+            signVerifiablePresentation: signCallback,
+            signatureSuite: signatureSuite,
             networkManager: network,
             openId4vp: openId4vp
         )
     }
-    
+
+    // MARK: - Basic
+
     func test_type_returns_openId4VpPresentation() {
-        let presentationDuringIssuanceAuthorizationMethodService = makeService(openId4vp: FakeOpenID4VP())
-        XCTAssertEqual(presentationDuringIssuanceAuthorizationMethodService.type(), InteractionType.openId4VpPresentation.rawValue)
+        let sut = makeService(openId4vp: FakeOpenID4VP())
+        XCTAssertEqual(
+            sut.type(),
+            InteractionType.openId4VpPresentation.rawValue
+        )
     }
-    
-    func test_authorizeUser_withInvalidRequestData_throws_error() async throws{
-        let presentationDuringIssuanceAuthorizationMethodService = makeService(openId4vp: FakeOpenID4VP())
-        
+
+    func test_invalidRequestData_throws_error() async {
+        let sut = makeService(openId4vp: FakeOpenID4VP())
+
         await XCTAssertThrowsErrorAsync {
-            _ = try await presentationDuringIssuanceAuthorizationMethodService.authorizeUser(requestData: DummyAuthorizationRequestData())
+            _ = try await sut.authorizeUser(
+                requestData: DummyAuthorizationRequestData()
+            )
         } verify: { error in
             XCTAssertTrue(error is InteractiveAuthorizationException)
-            XCTAssertEqual(error.localizedDescription, "Failed to authorize via interaction: Expected PresentationDuringIssuanceRequestData")
+            XCTAssertEqual(
+                error.localizedDescription,
+                "Failed to authorize via interaction: Expected PresentationDuringIssuanceRequestData"
+            )
         }
     }
-    
-    func test_validatePresentationRequest_throws_then_network_error_maps_to_errorResponse() async throws {
-        let fake = FakeOpenID4VP()
-        fake.behavior = .authThrows(GenericFailure(message: "bad auth", className: "Fake"))
-        let network = MockNetworkManager()
-        network.shouldThrowNetworkError = true
-        
-        let presentationDuringIssuanceAuthorizationMethodService = makeService(openId4vp: fake, network: network)
-        await XCTAssertThrowsErrorAsync {
-            _ = try await presentationDuringIssuanceAuthorizationMethodService.authorizeUser(requestData: self.makeRequestData())
-        } verify: { error in
-            XCTAssertTrue(error is InteractiveAuthorizationException)
-            XCTAssertEqual(error.localizedDescription, "Failed to authorize via interaction: Network error while posting VP response. Failed to download Credential: Simulated network failure")
-        }
-    }
-    
-    func test_validatePresentationRequest_throws_then_invalid_response_maps_to_errorResponse() async throws {
-        let fake = FakeOpenID4VP()
-        fake.behavior = .authThrows(GenericFailure(message: "bad auth", className: "Fake"))
-        let network = MockNetworkManager()
-        // Return non-JSON or wrong JSON so decoding fails
-        network.responseBody = "not a json"
-        
-        let presentationDuringIssuanceAuthorizationMethodService = makeService(openId4vp: fake, network: network)
-        await XCTAssertThrowsErrorAsync {
-            _ = try await presentationDuringIssuanceAuthorizationMethodService.authorizeUser(requestData: self.makeRequestData())
-        } verify: { error in
-            XCTAssertTrue(error is InteractiveAuthorizationException)
-            XCTAssertEqual(error.localizedDescription, "Failed to authorize via interaction: Issuer response deserialization failed.")
-        }
-    }
-    
-    func test_full_success_flow_returns_AuthorizationResponse_success() async throws {
+
+    // MARK: - Success
+
+    func test_full_success_flow_returns_success_response() async throws {
+
         let fake = FakeOpenID4VP()
         let network = MockNetworkManager()
-        // Prepare a successful AuthorizationResponse body
+
         let success = AuthorizationResponse(
             authorizationCode: "code-123",
             status: "success",
@@ -223,121 +186,103 @@ final class PresentationDuringIssuanceAuthorizationMethodServiceTests: XCTestCas
             errorDescription: nil,
             authSession: "auth-session-1"
         )
-        let data = try! JSONEncoder().encode(success)
-        network.responseBody = String(data: data, encoding: .utf8) ?? ""
-        
-        let presentationDuringIssuanceAuthorizationMethodService = makeService(openId4vp: fake, network: network)
-        let response = try await presentationDuringIssuanceAuthorizationMethodService.authorizeUser(requestData: makeRequestData())
-        
+
+        network.responseBody =
+        String(data: try JSONEncoder().encode(success), encoding: .utf8)!
+
+        let sut = makeService(
+            openId4vp: fake,
+            network: network
+        )
+
+        let response = try await sut.authorizeUser(
+            requestData: makeRequestData()
+        )
+
         XCTAssertEqual(response.status, "success")
         XCTAssertEqual(response.authorizationCode, "code-123")
-        XCTAssertEqual(response.authSession, "auth-session-1")
-        XCTAssertNil(response.error)
-        XCTAssertNil(response.errorDescription)
-        
-        // assert body params posted
         XCTAssertEqual(network.capturedParams["auth_session"], "auth-session-1")
         XCTAssertNotNil(network.capturedParams["openid4vp_response"])
     }
-    
-    func test_selectCredentials_timeout_is_mapped_to_constructed_error_and_posted() async throws{
-        let fake = FakeOpenID4VP()
+
+    // MARK: - Empty selection
+
+    func test_empty_selection_maps_to_access_denied_and_posts() async throws {
+
         let network = MockNetworkManager()
-        // Make selectCredentials hang beyond timeout by sleeping
-        let select: SelectCredentialsForPresentationCallback = { _ in
-            try await Task.sleep(nanoseconds: 600_000_000) // 600ms
-            return [:]
-        }
-        // Return a valid JSON error response from issuer to ensure outer flow continues
-        let errorResponse = AuthorizationResponse(
+
+        let issuerResponse = AuthorizationResponse(
             authorizationCode: nil,
             status: "error",
             error: "access_denied",
             errorDescription: "denied",
             authSession: "auth-session-1"
         )
-        let data = try! JSONEncoder().encode(errorResponse)
-        network.responseBody = String(data: data, encoding: .utf8) ?? ""
-        
-        let presentationDuringIssuanceAuthorizationMethodService = PresentationDuringIssuanceAuthorizationMethodService(
-            selectCredentialsForPresentation: select,
-            signVerifiablePresentation: { _ in [.ldp_vc: StubVPTokenSigningResult()] },
-            networkManager: network,
-            openId4vp: fake
+
+        network.responseBody =
+        String(data: try JSONEncoder().encode(issuerResponse), encoding: .utf8)!
+
+        let sut = makeService(
+            openId4vp: FakeOpenID4VP(),
+            network: network,
+            select: { _ in [:] }
         )
-        
-        let response = try await presentationDuringIssuanceAuthorizationMethodService.authorizeUser(requestData: makeRequestData())
-        XCTAssertEqual(response.status, "error")
+
+        let response = try await sut.authorizeUser(
+            requestData: makeRequestData()
+        )
+
         XCTAssertEqual(response.error, "access_denied")
-        XCTAssertEqual(network.capturedParams["auth_session"], "auth-session-1")
     }
-    
-    func test_signVerifiablePresentation_timeout_is_mapped_to_constructed_error_and_posted() async throws {
-        let fake = FakeOpenID4VP()
+
+    // MARK: - Network failure
+
+    func test_network_failure_throws_interactive_exception() async {
+
         let network = MockNetworkManager()
-        // select returns quickly
-        let select: SelectCredentialsForPresentationCallback = { _ in
-            return ["cred1": [.ldp_vc: [OpenID4VPAnyCodable("dummy-cred")]]]
-        }
-        // sign sleeps to trigger timeout
-        let sign: SignVerifiablePresentationCallback = { _ in
-            try await Task.sleep(nanoseconds: 600_000_000) // 600ms
-            return [.ldp_vc: StubVPTokenSigningResult()]
-        }
-        // Issuer returns an error JSON, still exercise network posting
-        let errorResponse = AuthorizationResponse(
-            authorizationCode: nil,
-            status: "error",
-            error: "server_error",
-            errorDescription: "timeout",
-            authSession: "auth-session-1"
+        network.shouldThrowNetworkError = true
+
+        let sut = makeService(
+            openId4vp: FakeOpenID4VP(),
+            network: network
         )
-        let data = try! JSONEncoder().encode(errorResponse)
-        network.responseBody = String(data: data, encoding: .utf8) ?? ""
-        
-        let presentationDuringIssuanceAuthorizationMethodService = PresentationDuringIssuanceAuthorizationMethodService(
-            selectCredentialsForPresentation: select,
-            signVerifiablePresentation: sign,
-            networkManager: network,
-            openId4vp: fake
-        )
-        
-        let response = try await presentationDuringIssuanceAuthorizationMethodService.authorizeUser(requestData: makeRequestData())
-        XCTAssertEqual(response.status, "error")
-        XCTAssertEqual(response.error, "server_error")
-        XCTAssertEqual(response.authSession, "auth-session-1")
-    }
-    
-    func test_error_when_signature_suite_not_provided_for_ldp_vc_selected_credentials() async throws {
-        let network = MockNetworkManager()
-        network.responseBody = """
-        {
-            "code": "code-123",
-            "status": "success",
-            "auth_session": "auth-session-1"
-        }
-        """
-        
-        let presentationDuringIssuanceAuthorizationMethodService = makeService(openId4vp: FakeOpenID4VP(), network: network)
-        _ = try await presentationDuringIssuanceAuthorizationMethodService.authorizeUser(requestData: makeRequestData())
-        
-        let errorSent = network.capturedParams
-        XCTAssertTrue(((errorSent["openid4vp_response"]?.contains("\"error_description\":\"constructed error: VCIClient.InteractiveAuthorizationException\"") == true)))
-        XCTAssertEqual(errorSent["auth_session"], "auth-session-1")
-    }
-    
-    func test_handle_network_timeout_during_vp_submission() async throws {
-        let network = MockNetworkManager()
-        network.shouldThrowTimeout = true
-        
-        let presentationDuringIssuanceAuthorizationMethodService = makeService(openId4vp: FakeOpenID4VP(), network: network)
+
         await XCTAssertThrowsErrorAsync {
-            _ = try await presentationDuringIssuanceAuthorizationMethodService.authorizeUser(requestData: self.makeRequestData())
+            _ = try await sut.authorizeUser(
+                requestData: self.makeRequestData()
+            )
         } verify: { error in
             XCTAssertTrue(error is InteractiveAuthorizationException)
-            XCTAssertEqual(error.localizedDescription, "Failed to authorize via interaction: Network error while posting VP response. Download failed due to request timeout: Simulated timeout")
+            XCTAssertTrue(
+                error.localizedDescription.contains(
+                    "Network error while posting VP response"
+                )
+            )
         }
-        
+    }
+
+    // MARK: - Invalid issuer response
+
+    func test_invalid_issuer_response_throws_deserialization_error() async {
+
+        let network = MockNetworkManager()
+        network.responseBody = "not-json"
+
+        let sut = makeService(
+            openId4vp: FakeOpenID4VP(),
+            network: network
+        )
+
+        await XCTAssertThrowsErrorAsync {
+            _ = try await sut.authorizeUser(
+                requestData: self.makeRequestData()
+            )
+        } verify: { error in
+            XCTAssertTrue(error is InteractiveAuthorizationException)
+            XCTAssertEqual(
+                error.localizedDescription,
+                "Failed to authorize via interaction: Issuer response deserialization failed."
+            )
+        }
     }
 }
-


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deprecations**
  * Two public credential-request methods are now deprecated with recommended replacement names; no runtime behavior changed.

* **Public API changes**
  * Presentation issuance parameter naming for the signature-suite has been renamed across the presentation/authorization surface and related types; call sites should be updated.

* **Tests**
  * Extensive test refactor and updates to reflect new token/response shapes and naming.

* **Chores**
  * External package reference updated to a different repository/branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->