### PR TITLE
Removed Claims from Credential Request Body in mso_mdoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,8 @@ val issuerMetadata = IssuerMetadata(
                         CredentialFormat.mso_mdoc )
 ```
 
+> **Note**: The `claims` parameter is optional in the OID4VCI specification for `mso_mdoc` format. While `claims` can be provided in `IssuerMetadata`, this implementation does not include `claims` in the credential request body for `mso_mdoc` format.
+
 3. Format: `vc+sd-jwt`
 ```
 val issuerMetadata = IssuerMetadata(

--- a/Sources/VCIClient/credential/request/types/MsoMdocVcCredentialRequest.swift
+++ b/Sources/VCIClient/credential/request/types/MsoMdocVcCredentialRequest.swift
@@ -40,19 +40,18 @@ class MsoMdocVcCredentialRequest: CredentialRequestProtocol {
             throw DownloadFailedException("Missing doctype in issuer metadata")
         }
 
-        let claims = issuerMetaData.claims.map { Util.convertToAnyCodable(dict: $0) }
-
         let credentialRequestBody = MsoMdocCredentialRequestBody(
             format: issuerMetaData.credentialFormat,
             doctype: doctype,
-            claims: claims,
             proof: proof as JWTProof
         )
 
         do {
             return try JSONEncoder().encode(credentialRequestBody)
         } catch {
-            print(logTag, "Error occurred while constructing request body: \(error.localizedDescription)")
+            print(
+                logTag,
+                "Error occurred while constructing request body: \(error.localizedDescription)")
             throw DownloadFailedException("Failed to encode credential request body")
         }
     }
@@ -61,12 +60,10 @@ struct MsoMdocCredentialRequestBody: Encodable {
     let format: CredentialFormat
     let proof: JWTProof
     let doctype: String
-    let claims: [String: AnyCodable]?
 
-    init(format: CredentialFormat, doctype: String, claims: [String: AnyCodable]?, proof: JWTProof) {
+    init(format: CredentialFormat, doctype: String, proof: JWTProof) {
         self.format = format
         self.doctype = doctype
         self.proof = proof
-        self.claims = claims
     }
 }


### PR DESCRIPTION
## Removed Claims From Credential Request Body in MSO Mdoc
- Removed the claims from request body for mso_mdoc request 
> Issue Ticket Number and Link
[INJIMOB-3574](https://mosip.atlassian.net/browse/INJIMOB-3574)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Credential requests for the mso_mdoc format no longer include issuer claims in the request payload; request construction and initialization were simplified accordingly.
* **Documentation**
  * README updated to note that claims are optional for mso_mdoc and are not included in this implementation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->