### PR TITLE
INJIMOB-3750: JWT-VC support

### DIFF
--- a/Sources/VCIClient/constants/CredentialFormat.swift
+++ b/Sources/VCIClient/constants/CredentialFormat.swift
@@ -2,6 +2,8 @@ import Foundation
 
 public enum CredentialFormat: String , Codable{
     case ldp_vc = "ldp_vc"
+    case jwt_vc_json = "jwt_vc_json"
+    case jwt_vc = "jwt_vc"
     case mso_mdoc = "mso_mdoc"
     case vc_sd_jwt = "vc+sd-jwt"
     case dc_sd_jwt = "dc+sd-jwt"

--- a/Sources/VCIClient/constants/CredentialFormat.swift
+++ b/Sources/VCIClient/constants/CredentialFormat.swift
@@ -3,7 +3,6 @@ import Foundation
 public enum CredentialFormat: String , Codable{
     case ldp_vc = "ldp_vc"
     case jwt_vc_json = "jwt_vc_json"
-    case jwt_vc = "jwt_vc"
     case mso_mdoc = "mso_mdoc"
     case vc_sd_jwt = "vc+sd-jwt"
     case dc_sd_jwt = "dc+sd-jwt"

--- a/Sources/VCIClient/credential/request/CredentialRequestFactory.swift
+++ b/Sources/VCIClient/credential/request/CredentialRequestFactory.swift
@@ -21,6 +21,12 @@ class CredentialRequestFactory: CredentialRequestFactoryProtocol {
                     accessToken: accessToken,
                     issuerMetaData: issuer,
                     proof: proofJwt as? JWTProof ?? JWTProof(jwt: "")))
+                    
+            case .jwt_vc, .jwt_vc_json:
+                 return try validateAndConstructCredentialRequest(credentialRequest: JwtVcCredentialRequest(
+                    accessToken: accessToken,
+                    issuerMetaData: issuer,
+                    proof: proofJwt as? JWTProof ?? JWTProof(jwt: "")))
             case .mso_mdoc:
                 return try validateAndConstructCredentialRequest(credentialRequest: MsoMdocVcCredentialRequest(accessToken: accessToken,
                                                                                                                issuerMetaData: issuer,

--- a/Sources/VCIClient/credential/request/CredentialRequestFactory.swift
+++ b/Sources/VCIClient/credential/request/CredentialRequestFactory.swift
@@ -10,31 +10,41 @@ public protocol CredentialRequestFactoryProtocol {
 
 class CredentialRequestFactory: CredentialRequestFactoryProtocol {
     static let shared = CredentialRequestFactory()
+    
     func createCredentialRequest(
         credentialFormat: CredentialFormat,
         accessToken: String,
         issuer: IssuerMetadata,
         proofJwt: Proof) throws -> URLRequest {
+
+            guard let proof = proofJwt as? JWTProof, !proof.jwt.isEmpty else {
+                throw InvalidDataProvidedException("Proof object cannot be empty or invalid")
+            }
+
             switch credentialFormat {
             case .ldp_vc:
                 return try validateAndConstructCredentialRequest(credentialRequest: LdpVcCredentialRequest(
                     accessToken: accessToken,
                     issuerMetaData: issuer,
-                    proof: proofJwt as? JWTProof ?? JWTProof(jwt: "")))
+                    proof: proof))
                     
             case .jwt_vc_json:
                  return try validateAndConstructCredentialRequest(credentialRequest: JwtVcCredentialRequest(
                     accessToken: accessToken,
                     issuerMetaData: issuer,
-                    proof: proofJwt as? JWTProof ?? JWTProof(jwt: "")))
+                    proof: proof))
+                    
             case .mso_mdoc:
-                return try validateAndConstructCredentialRequest(credentialRequest: MsoMdocVcCredentialRequest(accessToken: accessToken,
-                                                                                                               issuerMetaData: issuer,
-                                                                                                               proof: proofJwt as? JWTProof ?? JWTProof(jwt: "")))
-            case .vc_sd_jwt,.dc_sd_jwt:
-                return try validateAndConstructCredentialRequest(credentialRequest: SdJwtCredentialRequest(accessToken: accessToken,
-                                                                                                           issuerMetaData: issuer,
-                                                                                                           proof: proofJwt as? JWTProof ?? JWTProof(jwt: "")))
+                return try validateAndConstructCredentialRequest(credentialRequest: MsoMdocVcCredentialRequest(
+                    accessToken: accessToken, 
+                    issuerMetaData: issuer, 
+                    proof: proof))
+                    
+            case .vc_sd_jwt, .dc_sd_jwt:
+                return try validateAndConstructCredentialRequest(credentialRequest: SdJwtCredentialRequest(
+                    accessToken: accessToken, 
+                    issuerMetaData: issuer, 
+                    proof: proof))
             }
     }
 

--- a/Sources/VCIClient/credential/request/CredentialRequestFactory.swift
+++ b/Sources/VCIClient/credential/request/CredentialRequestFactory.swift
@@ -22,7 +22,7 @@ class CredentialRequestFactory: CredentialRequestFactoryProtocol {
                     issuerMetaData: issuer,
                     proof: proofJwt as? JWTProof ?? JWTProof(jwt: "")))
                     
-            case .jwt_vc, .jwt_vc_json:
+            case .jwt_vc_json:
                  return try validateAndConstructCredentialRequest(credentialRequest: JwtVcCredentialRequest(
                     accessToken: accessToken,
                     issuerMetaData: issuer,

--- a/Sources/VCIClient/credential/request/types/JwtVcCredentialRequest.swift
+++ b/Sources/VCIClient/credential/request/types/JwtVcCredentialRequest.swift
@@ -13,10 +13,10 @@ class JwtVcCredentialRequest: CredentialRequestProtocol {
 
     func validateIssuerMetadata() -> ValidatorResult {
         if issuerMetaData.credentialEndpoint.isEmpty {
-             return ValidatorResult(isValid: false, message: "Invalid or missing credentialEndpoint in issuer metadata")
+             return ValidatorResult(isValid: false)
         }
         if issuerMetaData.credentialType == nil || issuerMetaData.credentialType?.isEmpty == true {
-            return ValidatorResult(isValid: false, message: "Invalid or missing credentialType in issuer metadata")
+            return ValidatorResult(isValid: false)
         }
         return ValidatorResult(isValid: true)
     }
@@ -38,7 +38,7 @@ class JwtVcCredentialRequest: CredentialRequestProtocol {
     }
 
     private func generateRequestBody(proofJWT: JWTProof, issuer: IssuerMetadata) throws -> Data {
-        let definition = CredentialDefinition(type: issuer.credentialType ?? [])
+        let definition = JwtCredentialDefinition(type: issuer.credentialType ?? [])
         let requestBody = JwtVcCredentialRequestBody(
             format: issuer.credentialFormat,
             credential_definition: definition,
@@ -53,12 +53,12 @@ class JwtVcCredentialRequest: CredentialRequestProtocol {
     }
 }
 
-struct CredentialDefinition: Encodable {
+struct JwtCredentialDefinition: Encodable {
     let type: [String]
 }
 
 struct JwtVcCredentialRequestBody: Encodable {
     let format: CredentialFormat
-    let credential_definition: CredentialDefinition
+    let credential_definition: JwtCredentialDefinition
     let proof: JWTProof
 }

--- a/Sources/VCIClient/credential/request/types/JwtVcCredentialRequest.swift
+++ b/Sources/VCIClient/credential/request/types/JwtVcCredentialRequest.swift
@@ -15,6 +15,9 @@ class JwtVcCredentialRequest: CredentialRequestProtocol {
         if issuerMetaData.credentialEndpoint.isEmpty {
              return ValidatorResult(isValid: false, message: "Invalid or missing credentialEndpoint in issuer metadata")
         }
+        if issuerMetaData.credentialType == nil || issuerMetaData.credentialType?.isEmpty == true {
+            return ValidatorResult(isValid: false, message: "Invalid or missing credentialType in issuer metadata")
+        }
         return ValidatorResult(isValid: true)
     }
 
@@ -49,6 +52,7 @@ class JwtVcCredentialRequest: CredentialRequestProtocol {
         }
     }
 }
+
 struct CredentialDefinition: Encodable {
     let type: [String]
 }

--- a/Sources/VCIClient/credential/request/types/JwtVcCredentialRequest.swift
+++ b/Sources/VCIClient/credential/request/types/JwtVcCredentialRequest.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+class JwtVcCredentialRequest: CredentialRequestProtocol {
+    let accessToken: String
+    let issuerMetaData: IssuerMetadata
+    let proof: JWTProof
+
+    required init(accessToken: String, issuerMetaData: IssuerMetadata, proof: JWTProof) {
+        self.accessToken = accessToken
+        self.issuerMetaData = issuerMetaData
+        self.proof = proof
+    }
+
+    func validateIssuerMetadata() -> ValidatorResult {
+        return ValidatorResult()
+    }
+
+    func constructRequest() throws -> URLRequest {
+        guard let url = URL(string: issuerMetaData.credentialEndpoint) else {
+            throw DownloadFailedException("Invalid credential endpoint URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+
+        let body = try generateRequestBody(proofJWT: proof, issuer: issuerMetaData)
+        request.httpBody = body
+
+        return request
+    }
+
+    private func generateRequestBody(proofJWT: JWTProof, issuer: IssuerMetadata) throws -> Data {
+        let requestBody = JwtVcCredentialRequestBody(
+            format: issuer.credentialFormat,
+            proof: proofJWT
+        )
+
+        do {
+            return try JSONEncoder().encode(requestBody)
+        } catch {
+            throw DownloadFailedException("Failed to encode request body: \(error.localizedDescription)")
+        }
+    }
+}
+
+struct JwtVcCredentialRequestBody: Encodable {
+    let format: CredentialFormat
+    let proof: JWTProof
+
+    init(format: CredentialFormat, proof: JWTProof) {
+        self.format = format
+        self.proof = proof
+    }
+}

--- a/Sources/VCIClient/credential/request/types/JwtVcCredentialRequest.swift
+++ b/Sources/VCIClient/credential/request/types/JwtVcCredentialRequest.swift
@@ -12,7 +12,10 @@ class JwtVcCredentialRequest: CredentialRequestProtocol {
     }
 
     func validateIssuerMetadata() -> ValidatorResult {
-        return ValidatorResult()
+        if issuerMetaData.credentialEndpoint.isEmpty {
+             return ValidatorResult(isValid: false, message: "Invalid or missing credentialEndpoint in issuer metadata")
+        }
+        return ValidatorResult(isValid: true)
     }
 
     func constructRequest() throws -> URLRequest {
@@ -34,6 +37,7 @@ class JwtVcCredentialRequest: CredentialRequestProtocol {
     private func generateRequestBody(proofJWT: JWTProof, issuer: IssuerMetadata) throws -> Data {
         let requestBody = JwtVcCredentialRequestBody(
             format: issuer.credentialFormat,
+            types: issuer.credentialType ?? [],
             proof: proofJWT
         )
 
@@ -47,10 +51,6 @@ class JwtVcCredentialRequest: CredentialRequestProtocol {
 
 struct JwtVcCredentialRequestBody: Encodable {
     let format: CredentialFormat
+    let types: [String]
     let proof: JWTProof
-
-    init(format: CredentialFormat, proof: JWTProof) {
-        self.format = format
-        self.proof = proof
-    }
 }

--- a/Sources/VCIClient/credential/request/types/JwtVcCredentialRequest.swift
+++ b/Sources/VCIClient/credential/request/types/JwtVcCredentialRequest.swift
@@ -38,7 +38,11 @@ class JwtVcCredentialRequest: CredentialRequestProtocol {
     }
 
     private func generateRequestBody(proofJWT: JWTProof, issuer: IssuerMetadata) throws -> Data {
-        let definition = JwtCredentialDefinition(type: issuer.credentialType ?? [])
+        guard let credentialTypes = issuer.credentialType, !credentialTypes.isEmpty else {
+            throw InvalidDataProvidedException("Credential type is missing in issuer metadata")
+        }
+
+        let definition = JwtCredentialDefinition(type: credentialTypes)
         let requestBody = JwtVcCredentialRequestBody(
             format: issuer.credentialFormat,
             credential_definition: definition,

--- a/Sources/VCIClient/credential/request/types/JwtVcCredentialRequest.swift
+++ b/Sources/VCIClient/credential/request/types/JwtVcCredentialRequest.swift
@@ -35,9 +35,10 @@ class JwtVcCredentialRequest: CredentialRequestProtocol {
     }
 
     private func generateRequestBody(proofJWT: JWTProof, issuer: IssuerMetadata) throws -> Data {
+        let definition = CredentialDefinition(type: issuer.credentialType ?? [])
         let requestBody = JwtVcCredentialRequestBody(
             format: issuer.credentialFormat,
-            types: issuer.credentialType ?? [],
+            credential_definition: definition,
             proof: proofJWT
         )
 
@@ -48,9 +49,12 @@ class JwtVcCredentialRequest: CredentialRequestProtocol {
         }
     }
 }
+struct CredentialDefinition: Encodable {
+    let type: [String]
+}
 
 struct JwtVcCredentialRequestBody: Encodable {
     let format: CredentialFormat
-    let types: [String]
+    let credential_definition: CredentialDefinition
     let proof: JWTProof
 }

--- a/Sources/VCIClient/issuerMetadata/IssuerMetadataService.swift
+++ b/Sources/VCIClient/issuerMetadata/IssuerMetadataService.swift
@@ -83,10 +83,10 @@ class IssuerMetadataService {
 
     private func resolveMetadata(credentialConfigurationId: String, rawIssuerMetadata: [String: Any]) throws -> IssuerMetadata {
         guard let configurations = rawIssuerMetadata["credential_configurations_supported"] as? [String: Any],
-              let credentialType = configurations[credentialConfigurationId] as? [String: Any] else {
+            let credentialType = configurations[credentialConfigurationId] as? [String: Any] else {
             throw IssuerMetadataFetchException("Missing or invalid credential configuration")
         }
-
+        
         guard let credentialEndpoint = rawIssuerMetadata["credential_endpoint"] as? String else {
             throw IssuerMetadataFetchException("Missing credential_endpoint")
         }
@@ -144,6 +144,21 @@ class IssuerMetadataService {
                 credentialFormat: format,
                 authorizationServers: rawIssuerMetadata["authorization_servers"] as? [String],
                 vct: vct,
+                scope: scope
+            )
+
+        case .jwt_vc, .jwt_vc_json:
+            let definition = credentialType["credential_definition"] as? [String: Any] ?? [:]
+            let types = definition["type"] as? [String]
+            let context = (definition["context"] as? [String]) ?? (definition["@context"] as? [String])
+            
+            return IssuerMetadata(
+                credentialIssuer: credentialIssuer,
+                credentialEndpoint: credentialEndpoint,
+                credentialType: types,
+                context: context,
+                credentialFormat: format,
+                authorizationServers: rawIssuerMetadata["authorization_servers"] as? [String],
                 scope: scope
             )
         }

--- a/Sources/VCIClient/issuerMetadata/IssuerMetadataService.swift
+++ b/Sources/VCIClient/issuerMetadata/IssuerMetadataService.swift
@@ -147,7 +147,7 @@ class IssuerMetadataService {
                 scope: scope
             )
 
-        case .jwt_vc, .jwt_vc_json:
+        case .jwt_vc_json:
             let definition = credentialType["credential_definition"] as? [String: Any] ?? [:]
             let types = definition["type"] as? [String]
             let context = (definition["context"] as? [String]) ?? (definition["@context"] as? [String])

--- a/Sources/VCIClient/issuerMetadata/IssuerMetadataService.swift
+++ b/Sources/VCIClient/issuerMetadata/IssuerMetadataService.swift
@@ -83,10 +83,10 @@ class IssuerMetadataService {
 
     private func resolveMetadata(credentialConfigurationId: String, rawIssuerMetadata: [String: Any]) throws -> IssuerMetadata {
         guard let configurations = rawIssuerMetadata["credential_configurations_supported"] as? [String: Any],
-            let credentialType = configurations[credentialConfigurationId] as? [String: Any] else {
+              let credentialType = configurations[credentialConfigurationId] as? [String: Any] else {
             throw IssuerMetadataFetchException("Missing or invalid credential configuration")
         }
-        
+
         guard let credentialEndpoint = rawIssuerMetadata["credential_endpoint"] as? String else {
             throw IssuerMetadataFetchException("Missing credential_endpoint")
         }

--- a/Sources/VCIClient/issuerMetadata/IssuerMetadataService.swift
+++ b/Sources/VCIClient/issuerMetadata/IssuerMetadataService.swift
@@ -150,13 +150,12 @@ class IssuerMetadataService {
         case .jwt_vc_json:
             let definition = credentialType["credential_definition"] as? [String: Any] ?? [:]
             let types = definition["type"] as? [String]
-            let context = (definition["context"] as? [String]) ?? (definition["@context"] as? [String])
             
             return IssuerMetadata(
                 credentialIssuer: credentialIssuer,
                 credentialEndpoint: credentialEndpoint,
                 credentialType: types,
-                context: context,
+                context: nil,
                 credentialFormat: format,
                 authorizationServers: rawIssuerMetadata["authorization_servers"] as? [String],
                 scope: scope

--- a/Tests/VCIClientTests/credentialRequest/CredentialRequestFactoryTest.swift
+++ b/Tests/VCIClientTests/credentialRequest/CredentialRequestFactoryTest.swift
@@ -3,19 +3,21 @@ import XCTest
 
 final class CredentialRequestFactoryTests: XCTestCase {
 
+    private let validProof = JWTProof(jwt: "valid.jwt.string")
+
     func testCreateCredentialRequest_ldpvc_returnsValidRequest() throws {
         let factory = TestableCredentialRequestFactory()
         factory.credentialRequestToReturn = MockValidCredentialRequest(
             accessToken: "token",
             issuerMetaData: mockIssuerMetadata(),
-            proof: JWTProof(jwt: "")
+            proof: validProof
         )
 
         let request = try factory.createCredentialRequest(
             credentialFormat: .ldp_vc,
             accessToken: "token",
             issuer: mockIssuerMetadata(),
-            proofJwt: mockProof()
+            proofJwt: validProof
         )
 
         XCTAssertEqual(request.url?.absoluteString, "https://example.com")
@@ -26,17 +28,34 @@ final class CredentialRequestFactoryTests: XCTestCase {
         factory.credentialRequestToReturn = MockValidCredentialRequest(
             accessToken: "token",
             issuerMetaData: mockIssuerMetadata(),
-            proof: JWTProof(jwt: "")
+            proof: validProof
         )
 
         let request = try factory.createCredentialRequest(
             credentialFormat: .mso_mdoc,
             accessToken: "token",
             issuer: mockIssuerMetadata(),
-            proofJwt: mockProof()
+            proofJwt: validProof
         )
 
         XCTAssertEqual(request.url?.absoluteString, "https://example.com")
+    }
+
+    func testCreateCredentialRequest_emptyProof_throwsException() {
+        let factory = TestableCredentialRequestFactory()
+        let emptyProof = JWTProof(jwt: "")
+
+        XCTAssertThrowsError(
+            try factory.createCredentialRequest(
+                credentialFormat: .ldp_vc,
+                accessToken: "token",
+                issuer: mockIssuerMetadata(),
+                proofJwt: emptyProof
+            )
+        ) { error in
+            XCTAssertTrue(error is InvalidDataProvidedException)
+            XCTAssertEqual((error as? InvalidDataProvidedException)?.message, "Required details not provided : Proof object cannot be empty or invalid")
+        }
     }
 
     func testCreateCredentialRequest_invalidValidation_throwsException() {
@@ -44,7 +63,7 @@ final class CredentialRequestFactoryTests: XCTestCase {
         factory.credentialRequestToReturn = MockInvalidCredentialRequest(
             accessToken: "token",
             issuerMetaData: mockIssuerMetadata(),
-            proof: JWTProof(jwt: "")
+            proof: validProof
         )
 
         XCTAssertThrowsError(
@@ -52,7 +71,7 @@ final class CredentialRequestFactoryTests: XCTestCase {
                 credentialFormat: .ldp_vc,
                 accessToken: "token",
                 issuer: mockIssuerMetadata(),
-                proofJwt: mockProof()
+                proofJwt: validProof
             )
         ) { error in
             XCTAssertTrue(error is InvalidDataProvidedException)

--- a/Tests/VCIClientTests/credentialRequest/JwtVcCredentialRequestTests.swift
+++ b/Tests/VCIClientTests/credentialRequest/JwtVcCredentialRequestTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+@testable import VCIClient
+
+final class JwtVcCredentialRequestTests: XCTestCase {
+
+    var credentialRequest: JwtVcCredentialRequest!
+    let accessToken = "AccessToken"
+    let proofJWT = JWTProof(jwt: "xxxx.yyyy.zzzz")
+    let sampleEndpoint = "https://issuer.example.com/credential"
+    let sampleTypes = ["VerifiableCredential", "UniversityDegreeCredential"]
+
+    override func setUp() {
+        super.setUp()
+        let issuer = IssuerMetadata(
+            credentialIssuer: "https://issuer.example.com",
+            credentialEndpoint: sampleEndpoint,
+            credentialType: sampleTypes, // FIXED: Moved before credentialFormat
+            credentialFormat: .jwt_vc_json // FIXED: Likely naming convention
+        )
+        credentialRequest = JwtVcCredentialRequest(accessToken: accessToken, issuerMetaData: issuer, proof: proofJWT)
+    }
+
+    override func tearDown() {
+        credentialRequest = nil
+        super.tearDown()
+    }
+
+    // MARK: - Validation Tests
+
+    func testValidateIssuerMetadata_shouldReturnValid_whenCredentialTypeIsPresent() {
+        let result = credentialRequest.validateIssuerMetadata()
+        XCTAssertTrue(result.isValid)
+    }
+
+    func testValidateIssuerMetadata_shouldReturnInvalid_whenCredentialTypeIsNil() {
+        let issuerMissingType = IssuerMetadata(
+            credentialIssuer: "https://issuer.example.com",
+            credentialEndpoint: sampleEndpoint,
+            credentialType: nil, // FIXED: Moved before credentialFormat
+            credentialFormat: .jwt_vc_json
+        )
+
+        let requestWithMissingType = JwtVcCredentialRequest(accessToken: accessToken, issuerMetaData: issuerMissingType, proof: proofJWT)
+        let result = requestWithMissingType.validateIssuerMetadata()
+
+        XCTAssertFalse(result.isValid)
+        // Note: Removed message check because ValidatorResult doesn't support it
+    }
+
+    // MARK: - Construction Tests
+
+    func testConstructRequest_shouldReturnValidRequest_whenMetadataIsValid() {
+        do {
+            let request = try credentialRequest.constructRequest()
+
+            XCTAssertEqual(request.url?.absoluteString, sampleEndpoint)
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.allHTTPHeaderFields?["Content-Type"], "application/json")
+            XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], "Bearer \(accessToken)")
+            XCTAssertNotNil(request.httpBody)
+
+            if let bodyData = request.httpBody,
+               let json = try? JSONSerialization.jsonObject(with: bodyData) as? [String: Any] {
+                
+                XCTAssertEqual(json["format"] as? String, "jwt_vc_json")
+                
+                let definition = json["credential_definition"] as? [String: Any]
+                XCTAssertNotNil(definition)
+                XCTAssertEqual(definition?["type"] as? [String], sampleTypes)
+                
+                let proof = json["proof"] as? [String: Any]
+                XCTAssertEqual(proof?["jwt"] as? String, "xxxx.yyyy.zzzz")
+            } else {
+                XCTFail("Request body is nil or not convertible to JSON")
+            }
+
+        } catch {
+            XCTFail("Unexpected error during request construction: \(error)")
+        }
+    }
+}

--- a/Tests/VCIClientTests/credentialRequest/JwtVcCredentialRequestTests.swift
+++ b/Tests/VCIClientTests/credentialRequest/JwtVcCredentialRequestTests.swift
@@ -14,8 +14,8 @@ final class JwtVcCredentialRequestTests: XCTestCase {
         let issuer = IssuerMetadata(
             credentialIssuer: "https://issuer.example.com",
             credentialEndpoint: sampleEndpoint,
-            credentialType: sampleTypes, // FIXED: Moved before credentialFormat
-            credentialFormat: .jwt_vc_json // FIXED: Likely naming convention
+            credentialType: sampleTypes,
+            credentialFormat: .jwt_vc_json
         )
         credentialRequest = JwtVcCredentialRequest(accessToken: accessToken, issuerMetaData: issuer, proof: proofJWT)
     }
@@ -24,8 +24,6 @@ final class JwtVcCredentialRequestTests: XCTestCase {
         credentialRequest = nil
         super.tearDown()
     }
-
-    // MARK: - Validation Tests
 
     func testValidateIssuerMetadata_shouldReturnValid_whenCredentialTypeIsPresent() {
         let result = credentialRequest.validateIssuerMetadata()
@@ -36,7 +34,7 @@ final class JwtVcCredentialRequestTests: XCTestCase {
         let issuerMissingType = IssuerMetadata(
             credentialIssuer: "https://issuer.example.com",
             credentialEndpoint: sampleEndpoint,
-            credentialType: nil, // FIXED: Moved before credentialFormat
+            credentialType: nil,
             credentialFormat: .jwt_vc_json
         )
 
@@ -44,10 +42,7 @@ final class JwtVcCredentialRequestTests: XCTestCase {
         let result = requestWithMissingType.validateIssuerMetadata()
 
         XCTAssertFalse(result.isValid)
-        // Note: Removed message check because ValidatorResult doesn't support it
     }
-
-    // MARK: - Construction Tests
 
     func testConstructRequest_shouldReturnValidRequest_whenMetadataIsValid() {
         do {

--- a/Tests/VCIClientTests/credentialRequest/JwtVcCredentialRequestTests.swift
+++ b/Tests/VCIClientTests/credentialRequest/JwtVcCredentialRequestTests.swift
@@ -44,7 +44,25 @@ final class JwtVcCredentialRequestTests: XCTestCase {
         XCTAssertFalse(result.isValid)
     }
 
+    func testConstructRequest_shouldThrow_whenCredentialTypeIsMissing() {
+        let issuerMissingType = IssuerMetadata(
+            credentialIssuer: "https://issuer.example.com",
+            credentialEndpoint: sampleEndpoint,
+            credentialType: nil,
+            credentialFormat: .jwt_vc_json
+        )
+        
+        let requestWithMissingType = JwtVcCredentialRequest(accessToken: accessToken, issuerMetaData: issuerMissingType, proof: proofJWT)
+        
+        XCTAssertThrowsError(try requestWithMissingType.constructRequest()) { error in
+            XCTAssertTrue(error is InvalidDataProvidedException)
+            XCTAssertEqual((error as? InvalidDataProvidedException)?.message, "Required details not provided : Credential type is missing in issuer metadata")
+        }
+    }
+
     func testConstructRequest_shouldReturnValidRequest_whenMetadataIsValid() {
+        XCTAssertNoThrow(try credentialRequest.constructRequest())
+        
         do {
             let request = try credentialRequest.constructRequest()
 


### PR DESCRIPTION
## Description
This PR enables the iOS VCIClient library to support JWT Verifiable Credentials (jwt_vc_json). It updates the core metadata resolution and format validation logic to handle the jwt_vc_json format, facilitating end-to-end issuance flows compatible with OpenID4VCI standards.

## Changes

**Core Feature Implementation:**
- CredentialFormat.swift: Added the jwt_vc_json case to the supported formats enum to match industry standards and server outputs.
- IssuerMetadataService.swift: Updated the resolveMetadata logic to recognize and map the jwt_vc_json format from issuer metadata during the discovery phase.
- CredentialRequestFactory.swift: Updated the internal factory to support the creation of credential requests specifically for the jwt_vc_json format.
- JwtVcCredentialRequest.swift: Implemented the new request class required to structure and sign JWT-based verifiable credentials.

**Local Setup & Environment (Excluded from PR):**
To ensure a clean production-ready merge, the following local development and testing configurations have been intentionally excluded from this PR:
- VCIClientWrapper.swift: Local testing used a manual request bypass to verify network integrity and server compatibility while troubleshooting environment-specific caching issues.
- Info.plist: Temporary App Transport Security overrides used for local IP testing (192.168.x.x) were removed to maintain strict HTTPS production standards.
- IssuerConfig.swift: Environment-specific URLs and mock service endpoints have been reverted to maintain project consistency.

## Ticket ID and Link
[INJIMOB-3750](https://mosip.atlassian.net/browse/INJIMOB-3750)

## Testing
**Methodology:**
Validated changes using the internal Swift example app. Due to local environment caching issues (Xcode DerivedData persistence), a manual network bypass was implemented in the example app to confirm that the server correctly issues the jwt_vc_json format and that the library's new enum cases are functionally correct.

**Verification Steps:**
Credential Discovery: Triggered the "Fetch Credential Types" action in the sample app.
Result: Confirmed that JwtVerifiableCredential is correctly identified and listed via the browser-verified metadata output.

**End-to-End Issuance:**
Initiated the full credential flow using a local test harness pointing to the verified mock server.
Result: Successfully retrieved a mathematically signed JWT Verifiable Credential.
Validation: Verified the success payload contains the expected format: "jwt_vc_json" and valid credential data.

## Screenshots
<img width="200" height="600" alt="image" src="https://github.com/user-attachments/assets/a2dfed67-6dc5-4017-a14b-6e2a06c6de3b" />
<img width="200" height="600" alt="image" src="https://github.com/user-attachments/assets/a3b16fda-6e85-4183-a0da-a6494ca36021" />
<img width="200" height="600" alt="image" src="https://github.com/user-attachments/assets/bdf2cc2e-b0a2-467a-a76f-9aa0de4498a8" />

## Video
https://github.com/user-attachments/assets/a54db7bc-9d30-4fcf-9730-cb3b01052b3d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the jwt_vc_json credential format across the client.
  * New credential request flow for jwt_vc_json enabling token-authenticated POST issuance requests.
  * Issuer metadata resolution now parses jwt_vc_json credential definitions to populate credential type and context for complete metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->