### PR TITLE
[INJIMOB-3694] doc: update readme of vci client for new fetch* methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ It supports **Issuer Initiated (Credential Offer)** and **Wallet Initiated (Trus
 
 ---
 
+## 📋 Specifications supported
+
+The implementation follows
+- OpenID for Verifiable Credential Issuance - draft 11
+- OpenID for Verifiable Credential Issuance - draft 13
+
 ## ✨ Features
 
 - Request credentials from OID4VCI-compliant credential issuers
@@ -19,9 +25,15 @@ It supports **Issuer Initiated (Credential Offer)** and **Wallet Initiated (Trus
   - `ldp_vc`
   - `mso_mdoc`
   - `vc+sd-jwt` / `dc+sd-jwt`
+- Presentation During Issuance (PDI) support for both download flows
 
 > ⚠️ Consumer of this library is responsible for processing and rendering the credential after it is downloaded.
 
+## 📚 Library implementations available in:
+This library is officially supported and available in both Kotlin and Swift, ensuring seamless integration across Android and iOS platforms. The references for both implementations are provided below:
+
+* [Kotlin](https://github.com/inji/inji-vci-client/tree/master/kotlin)
+* [Swift](.)
 ---
 
 ## 📦 Installation
@@ -29,7 +41,7 @@ It supports **Issuer Initiated (Credential Offer)** and **Wallet Initiated (Trus
 Add VCIClient to your Swift Package Manager dependencies:
 
 ```swift
-.package(url: "https://github.com/mosip/inji-vci-client-ios", from: "0.5.0")
+.package(url: "https://github.com/mosip/inji-vci-client-ios", from: "0.7.0")
 ```
 
 ## 🏗️ Construction of VCIClient instance
@@ -63,7 +75,7 @@ Retrieve the issuer metadata from the credential issuer's well-known endpoint.
 
 `IssuerMetadata` object containing details like `credential_endpoint`, `credential_issuer`, and other IssuerMetadata information from the well-known endpoint of Credential Issuer, which can be used by the consumer to display Issuer information, etc.
 
-> Note: This method does not parse the metadata, it simply returns the raw Network response of well-known endpoint as a `Map<String, Any>`.
+> Note: This method does not parse the metadata, it simply returns the raw Network response of well-known endpoint as a `[String: Any]`.
 
 #### Example Usage
 
@@ -92,7 +104,7 @@ Map of `credential_configurations_supported` objects containing details like `fo
 information from the well-known endpoint of Credential Issuer, which can be used by the consumer to display supported
 credential types, etc.
 
-> Note: This method does not parse the metadata, it simply returns the raw Network response of well-known endpoint as a `Map<String, Any>`.
+> Note: This method does not parse the metadata, it simply returns the raw Network response of well-known endpoint as a `[String: Any]`.
 
 #### Example Usage
 
@@ -118,56 +130,63 @@ let credentialConfigurationsSupported : [String: Any] = try await vciClient.getC
 
 ### 3. Request Credential
 
-### 3.1 Request Credential by Credential Offer
+### 3.1 Request Credential using Credential Offer
 
-- Method: `requestCredentialByCredentialOffer`
-- This method allows you to request a credential using a credential offer, which can be either an embedded JSON or a URI pointing to the credential offer.
+#### fetchCredentialUsingCredentialOffer
+
+- Method: `fetchCredentialUsingCredentialOffer`
+- This method allows you to fetch a credential using a credential offer, which can be either an embedded JSON or a URI pointing to the credential offer.
 - It supports both **Pre-Authorization** and **Authorization** flows.
 - The library handles the PKCE flow internally.
-- user-trust based credential download supported through onCheckIssuerTrust callback.
+- User-trust based credential download supported through onCheckIssuerTrust callback.
+- This method is the recommended way to request credential using credential offer.
 
-#### Parameters
+###### Parameters
 
-| Name                    | Type                     | Required | Default Value | Description                                                                                 |
-|-------------------------|--------------------------|----------|---------------|---------------------------------------------------------------------------------------------|
-| credentialOffer         | String                   | Yes      | N/A           | Credential offer as embedded JSON or `credential_offer_uri`                                 |
-| clientMetadata          | ClientMetadata           | Yes      | N/A           | Contains client ID and redirect URI                                                         |
-| getTxCode               | TxCodeCallback           | No       | N/A           | Optional callback function for TX Code (for Pre-Auth flows)                                 |
-| authorizeUser           | AuthorizeUserCallback    | Yes      | N/A           | Handles authorization and returns the code (for Authorization flows)                        |
-| getTokenResponse        | TokenResponseCallback    | Yes      | N/A           | Callback function to exchange Authorization Grant with Access Token response                |
-| getProofJwt             | ProofJwtCallback         | Yes      | N/A           | Callback function to prepare proof-jwt for Credential Request                               |
-| onCheckIssuerTrust      | CheckIssuerTrustCallback | No       | null          | Callback function to get user trust with the Credential Issuer                              |
-| downloadTimeoutInMillis | Long                     | No       | 10000         | Download timeout set for Credential Request call with Credential Issuer (defaults to 10 ms) |
+| Name                    | Type                     | Required | Default Value | Description                                                                                                                                                                               |
+|-------------------------|--------------------------|----------|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| credentialOffer         | String                   | Yes      | N/A           | Credential offer as embedded JSON or `credential_offer_uri`                                                                                                                               |
+| clientMetadata          | ClientMetadata           | Yes      | N/A           | Contains client ID and redirect URI                                                                                                                                                       |
+| getTxCode               | TxCodeCallback           | No       | N/A           | Optional callback function for TX Code (for Pre-Auth flows)                                                                                                                               |
+| authorizationMethods    | [AuthorizationMethod]    | Yes      | N/A           | Callback functions list to handle authorization and return the resultant authorization response (for Authorization flows) [click [here](#authorizations) for details about authorization] |
+| getTokenResponse        | TokenResponseCallback    | Yes      | N/A           | Callback function to exchange Authorization Grant with Access Token response                                                                                                              |
+| getProofJwt             | ProofJwtCallback         | Yes      | N/A           | Callback function to prepare proof-jwt for Credential Request                                                                                                                             |
+| onCheckIssuerTrust      | CheckIssuerTrustCallback | No       | nil           | Callback function to get user trust with the Credential Issuer                                                                                                                            |
+| downloadTimeoutInMillis | Int64                    | No       | 10000         | Download timeout set for Credential Request call with Credential Issuer (defaults to 10000 ms)                                                                                            |
 
-#### Returns
+###### Returns
 
 An instance of `CredentialResponse` containing:
 
-| Name                      | Type        | Description                                                                    |
-|---------------------------|-------------|--------------------------------------------------------------------------------|
-| credential                | JsonElement | The credential downloaded from the Issuer                                      |
-| credentialConfigurationId | String      | The identifier of the respective supported credential from well-known response |
-| credentialIssuer          | String      | URI of the Credential Issuer                                                   |
+| Name                      | Type       | Description                                                                    |
+|---------------------------|------------|--------------------------------------------------------------------------------|
+| credential                | AnyCodable | The credential downloaded from the Issuer                                      |
+| credentialConfigurationId | String?    | The identifier of the respective supported credential from well-known response |
+| credentialIssuer          | String?    | URI of the Credential Issuer                                                   |
 
-
-#### Example usage
+###### Example usage
 
 ```swift
-let credentialResponse = try await vciClient.requestCredentialByCredentialOffer(
+let credentialResponse : CredentialResponse = try await vciClient.fetchCredentialUsingCredentialOffer(
     credentialOffer: "openid-credential-offer://?credential_offer_uri=https%3A%2F%2Fsample-issuer.com%2Fcredential-offer",
-    clientMetadata: ClientMetadata(
-        clientId: "sample-client-id",
-        redirectUri: "https://sample-wallet.com/callback"
-    ),
-    getTxCode: { credentialIssuer, displayData, timeoutInMillis in
-        // Handle transaction code retrieval logic here
-        return "sampleTxCode"
+    clientMetadata: ClientMetadata(clientId: "sample-client-id", redirectUri: "https://sample-wallet.com/callback"),
+    getTxCode: { inputMode, description, length in
+        // Handle the transaction code retrieval logic here
+        let txCode = "sampleTxCode"
+        return txCode
     },
-    authorizeUser: { authEndpoint in
-        // Handle user authorization logic here
-        return "sampleAuthCode"
-    },
+    authorizationMethods: [
+        // Presentation During Issuance flow for authorization
+        .presentationDuringIssuance(
+            selectCredentialsForPresentation: selectCredentialsForPresentationCallback(),
+            signVerifiablePresentation: signVerifiablePresentationCallback(),
+            ldpVpSignatureSuite: "Ed25519Signature2020"
+        ),
+        // Redirect to Web flow for Web view authorization
+        .redirectToWeb(openWebPage: openWebPageCallback())
+    ],
     getTokenResponse: { tokenRequest in
+        // Handle the token response retrieval logic here
         // Exchange authorization code for access token
         return TokenResponse(
             accessToken: "sampleAccessToken",
@@ -177,26 +196,207 @@ let credentialResponse = try await vciClient.requestCredentialByCredentialOffer(
             cNonceExpiresIn: 3600
         )
     },
-    getProofJwt: { credentialIssuer, cNonce, proofSigningAlgosSupported in
-        // Sign the JWT with the private key
-        return "sampleProofJwt"
+    getProofJwt: { credentialIssuer, cNonce, proofSigningAlgorithmsSupported in
+        // Prepare payload for JWT
+        // Sign the JWT with the private key as per the proofSigningAlgorithmsSupported
+        let jwt = "sampleProofJwt"
+        return jwt
     },
     onCheckIssuerTrust: { credentialIssuer, issuerDisplay in
-        // Handle trust check
-        return true
+        // Handle the issuer trust check logic here
+        return true // Assume the issuer is trusted for this example
     },
     downloadTimeoutInMillis: 10_000
 )
 
-// Access the credential fields
-let credential = credentialResponse.credential  // This will be a JsonElement containing the credential data. eg - JsonPrimitive("omdk...t")
-let credentialConfigId = credentialResponse.credentialConfigurationId // eg - "DriversLicense"
-let credentialIssuer = credentialResponse.credentialIssuer // eg - "https://sample-issuer.com"
+// Consider the credential is a Driver's license credential (credential format `mso_mdoc`)
+let credentialResponse = try await vciClient.fetchCredentialUsingCredentialOffer(
+    credentialOffer: credentialOffer,
+    clientMetadata: clientMetadata,
+    getTxCode: getTxCode,
+    authorizationMethods: authorizationMethods,
+    getTokenResponse: getTokenResponse,
+    getProofJwt: getProofJwt,
+    onCheckIssuerTrust: onCheckIssuerTrust,
+    downloadTimeoutInMillis: downloadTimeoutInMillis
+)
+credentialResponse?.credential // This will contain the credential data
+credentialResponse?.credentialConfigurationId // eg - "DriversLicense"
+credentialResponse?.credentialIssuer // eg - "https://sample-issuer.com"
+```
 
+#### requestCredentialByCredentialOffer (deprecated - use `fetchCredentialUsingCredentialOffer` instead)
+
+- Method: `requestCredentialByCredentialOffer`
+- This method allows you to request a credential using a credential offer, which can be either an embedded JSON or a URI pointing to the credential offer.
+- It supports both **Pre-Authorization** and **Authorization** flows.
+- The library handles the PKCE flow internally.
+- User-trust based credential download supported through onCheckIssuerTrust callback.
+
+###### Parameters
+
+| Name                    | Type                     | Required | Default Value | Description                                                                                    |
+|-------------------------|--------------------------|----------|---------------|------------------------------------------------------------------------------------------------|
+| credentialOffer         | String                   | Yes      | N/A           | Credential offer as embedded JSON or `credential_offer_uri`                                    |
+| clientMetadata          | ClientMetadata           | Yes      | N/A           | Contains client ID and redirect URI                                                            |
+| getTxCode               | TxCodeCallback           | No       | N/A           | Optional callback function for TX Code (for Pre-Auth flows)                                    |
+| authorizeUser           | AuthorizeUserCallback    | Yes      | N/A           | Handles authorization and returns the code (for Authorization flows)                           |
+| getTokenResponse        | TokenResponseCallback    | Yes      | N/A           | Callback function to exchange Authorization Grant with Access Token response                   |
+| getProofJwt             | ProofJwtCallback         | Yes      | N/A           | Callback function to prepare proof-jwt for Credential Request                                  |
+| onCheckIssuerTrust      | CheckIssuerTrustCallback | No       | nil           | Callback function to get user trust with the Credential Issuer                                 |
+| downloadTimeoutInMillis | Int64                    | No       | 10000         | Download timeout set for Credential Request call with Credential Issuer (defaults to 10000 ms) |
+
+###### Returns
+
+An instance of `CredentialResponse` containing:
+
+| Name                      | Type       | Description                                                                    |
+|---------------------------|------------|--------------------------------------------------------------------------------|
+| credential                | AnyCodable | The credential downloaded from the Issuer                                      |
+| credentialConfigurationId | String?    | The identifier of the respective supported credential from well-known response |
+| credentialIssuer          | String?    | URI of the Credential Issuer                                                   |
+
+###### Example usage
+
+```swift
+let credentialResponse : CredentialResponse = try await vciClient.requestCredentialByCredentialOffer(
+    credentialOffer: "openid-credential-offer://?credential_offer_uri=https%3A%2F%2Fsample-issuer.com%2Fcredential-offer",
+    clientMetadata: ClientMetadata(clientId: "sample-client-id", redirectUri: "https://sample-wallet.com/callback"),
+    getTxCode: { inputMode, description, length in
+        // Handle the transaction code retrieval logic here
+        let txCode = "sampleTxCode"
+        return txCode
+    },
+    authorizeUser: { authEndpoint in
+        // Handle the user authorization logic here
+        let authCode = "sampleAuthCode"
+        return authCode
+    },
+    getTokenResponse: { tokenRequest in
+        // Handle the token response retrieval logic here
+        // Exchange authorization code for access token
+        return TokenResponse(
+            accessToken: "sampleAccessToken",
+            cNonce: "sampleNonce",
+            tokenType: "Bearer",
+            expiresIn: 3600,
+            cNonceExpiresIn: 3600
+        )
+    },
+    getProofJwt: { credentialIssuer, cNonce, proofSigningAlgorithmsSupported in
+        // Prepare payload for JWT
+        // Sign the JWT with the private key as per the proofSigningAlgorithmsSupported
+        let jwt = "sampleProofJwt"
+        return jwt
+    },
+    onCheckIssuerTrust: { credentialIssuer, issuerDisplay in
+        // Handle the issuer trust check logic here
+        return true // Assume the issuer is trusted for this example
+    },
+    downloadTimeoutInMillis: 10000
+)
+
+// Consider the credential is a Driver's license credential (credential format `mso_mdoc`)
+let credentialResponse = try await vciClient.requestCredentialByCredentialOffer(
+    credentialOffer: credentialOffer,
+    clientMetadata: clientMetadata,
+    getTxCode: getTxCode,
+    authorizeUser: authorizeUser,
+    getTokenResponse: getTokenResponse,
+    getProofJwt: getProofJwt,
+    onCheckIssuerTrust: onCheckIssuerTrust,
+    downloadTimeoutInMillis: downloadTimeoutInMillis
+)
+credentialResponse?.credential // This will contain the credential data
+credentialResponse?.credentialConfigurationId // eg - "DriversLicense"
+credentialResponse?.credentialIssuer // eg - "https://sample-issuer.com"
 ```
 
 ### 3.2 Request Credential from Trusted Issuer
 
+#### fetchCredentialFromTrustedIssuer
+- Method: `fetchCredentialFromTrustedIssuer`
+- It supports **Authorization** flow.
+- The library handles the PKCE flow internally.
+
+#### Parameters
+
+| Name                      | Type                  | Required | Default Value | Description                                                                                                                                                                               |
+|---------------------------|-----------------------|----------|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| credentialIssuer          | String                | Yes      | N/A           | URI of the Credential Issuer                                                                                                                                                              |
+| credentialConfigurationId | String                | Yes      | N/A           | Identifier of the respective supported credential from well-known response                                                                                                                |
+| clientMetadata            | ClientMetadata        | Yes      | N/A           | Contains client ID and redirect URI                                                                                                                                                       |
+| authorizationMethods      | [AuthorizationMethod] | Yes      | N/A           | Callback functions list to handle authorization and return the resultant authorization response (for Authorization flows) [click [here](#authorizations) for details about authorization] |
+| getTokenResponse          | TokenResponseCallback | Yes      | N/A           | Callback function to exchange Authorization Grant with Access Token response                                                                                                              |
+| getProofJwt               | ProofJwtCallback      | Yes      | N/A           | Callback function to prepare proof-jwt for Credential Request                                                                                                                             |
+| downloadTimeoutInMillis   | Int64                 | No       | 10000         | Download timeout set for Credential Request call with Credential Issuer (defaults to 10000 ms)                                                                                            |
+
+#### Returns
+
+An instance of `CredentialResponse` containing:
+
+| Name                      | Type       | Description                                                                    |
+|---------------------------|------------|--------------------------------------------------------------------------------|
+| credential                | AnyCodable | The credential downloaded from the Issuer                                      |
+| credentialConfigurationId | String?    | The identifier of the respective supported credential from well-known response |
+| credentialIssuer          | String?    | URI of the Credential Issuer                                                   |
+
+#### Example usage
+
+```swift
+let credentialResponse = try await vciClient.fetchCredentialFromTrustedIssuer(
+    credentialIssuer: "https://sample-issuer.com",
+    credentialConfigurationId: "DriversLicense",
+    clientMetadata: ClientMetadata(
+        clientId: "sample-client-id",
+        redirectUri: "https://sample-wallet.com/callback"
+    ),
+    authorizationMethods: [
+        // Presentation During Issuance flow for authorization
+        .presentationDuringIssuance(
+            selectCredentialsForPresentation: selectCredentialsForPresentationCallback(),
+            signVerifiablePresentation: signVerifiablePresentationCallback(),
+            ldpVpSignatureSuite: "Ed25519Signature2020"
+        ),
+        // Redirect to Web flow for Web view authorization
+        .redirectToWeb(openWebPage: openWebPageCallback())
+    ],
+    getTokenResponse: { tokenRequest in
+        // Handle the token response retrieval logic here
+        // Exchange authorization code for access token
+        return TokenResponse(
+            accessToken: "sampleAccessToken",
+            cNonce: "sampleNonce",
+            tokenType: "Bearer",
+            expiresIn: 3600,
+            cNonceExpiresIn: 3600
+        )
+    },
+    getProofJwt: { credentialIssuer, cNonce, proofSigningAlgorithmsSupported in
+        // Prepare payload for JWT
+        // Sign the JWT with the private key as per the proofSigningAlgorithmsSupported
+        let jwt = "sampleProofJwt"
+        return jwt
+    },
+    downloadTimeoutInMillis: 10000
+)
+
+// Consider the credential is a Driver's license credential (credential format `mso_mdoc`)
+let credentialResponse : CredentialResponse = try await vciClient.fetchCredentialFromTrustedIssuer(
+    credentialIssuer: credentialIssuer,
+    credentialConfigurationId: credentialConfigurationId,
+    clientMetadata: clientMetadata,
+    authorizationMethods: authorizationMethods,
+    getTokenResponse: getTokenResponse,
+    getProofJwt: getProofJwt,
+    downloadTimeoutInMillis: downloadTimeoutInMillis
+)
+credentialResponse?.credential // This will contain the credential data
+credentialResponse?.credentialConfigurationId // eg - "DriversLicense"
+credentialResponse?.credentialIssuer // eg - "https://sample-issuer.com"
+```
+
+#### requestCredentialFromTrustedIssuer (deprecated - use `fetchCredentialFromTrustedIssuer` instead)
 - Method: `requestCredentialFromTrustedIssuer`
 - This method allows you to request a credential from a trusted issuer of Wallet.
 - It supports **Authorization** flow.
@@ -204,30 +404,30 @@ let credentialIssuer = credentialResponse.credentialIssuer // eg - "https://samp
 
 #### Parameters
 
-| Name                      | Type                  | Required | Default Value | Description                                                                                 |
-|---------------------------|-----------------------|----------|---------------|---------------------------------------------------------------------------------------------|
-| credentialIssuer          | String                | Yes      | N/A           | URI of the Credential Issuer                                                                |
-| credentialConfigurationId | String                | Yes      | N/A           | Identifier of the respective supported credential from well-known response                  |
-| clientMetadata            | ClientMetadata        | Yes      | N/A           | Contains client ID and redirect URI                                                         |
-| authorizeUser             | AuthorizeUserCallback | Yes      | N/A           | Handles authorization and returns the code (for Authorization flows)                        |
-| getTokenResponse          | TokenResponseCallback | Yes      | N/A           | Callback function to exchange Authorization Grant with Access Token response                |
-| getProofJwt               | ProofJwtCallback      | Yes      | N/A           | Callback function to prepare proof-jwt for Credential Request                               |
-| downloadTimeoutInMillis   | Long                  | No       | 10000         | Download timeout set for Credential Request call with Credential Issuer (defaults to 10 ms) |
+| Name                      | Type                  | Required | Default Value | Description                                                                                    |
+|---------------------------|-----------------------|----------|---------------|------------------------------------------------------------------------------------------------|
+| credentialIssuer          | String                | Yes      | N/A           | URI of the Credential Issuer                                                                   |
+| credentialConfigurationId | String                | Yes      | N/A           | Identifier of the respective supported credential from well-known response                     |
+| clientMetadata            | ClientMetadata        | Yes      | N/A           | Contains client ID and redirect URI                                                            |
+| authorizeUser             | AuthorizeUserCallback | Yes      | N/A           | Handles authorization and returns the code (for Authorization flows)                           |
+| getTokenResponse          | TokenResponseCallback | Yes      | N/A           | Callback function to exchange Authorization Grant with Access Token response                   |
+| getProofJwt               | ProofJwtCallback      | Yes      | N/A           | Callback function to prepare proof-jwt for Credential Request                                  |
+| downloadTimeoutInMillis   | Int64                 | No       | 10000         | Download timeout set for Credential Request call with Credential Issuer (defaults to 10000 ms) |
 
 #### Returns
 
 An instance of `CredentialResponse` containing:
 
-| Name                      | Type        | Description                                                                    |
-|---------------------------|-------------|--------------------------------------------------------------------------------|
-| credential                | JsonElement | The credential downloaded from the Issuer                                      |
-| credentialConfigurationId | String      | The identifier of the respective supported credential from well-known response |
-| credentialIssuer          | String      | URI of the Credential Issuer                                                   |
+| Name                      | Type       | Description                                                                    |
+|---------------------------|------------|--------------------------------------------------------------------------------|
+| credential                | AnyCodable | The credential downloaded from the Issuer                                      |
+| credentialConfigurationId | String?    | The identifier of the respective supported credential from well-known response |
+| credentialIssuer          | String?    | URI of the Credential Issuer                                                   |
 
 #### Example usage
 
 ```swift
-let credentialResponse = try await vciClient.requestCredentialFromTrustedIssuer(
+let credentialResponse : CredentialResponse = try await vciClient.requestCredentialFromTrustedIssuer(
     credentialIssuer: "https://sample-issuer.com",
     credentialConfigurationId: "DriversLicense",
     clientMetadata: ClientMetadata(
@@ -235,10 +435,12 @@ let credentialResponse = try await vciClient.requestCredentialFromTrustedIssuer(
         redirectUri: "https://sample-wallet.com/callback"
     ),
     authorizeUser: { authEndpoint in
-        // Handle user authorization logic here
-        return "sampleAuthCode"
+        // Handle the user authorization logic here
+        let authCode = "sampleAuthCode"
+        return authCode
     },
     getTokenResponse: { tokenRequest in
+        // Handle the token response retrieval logic here
         // Exchange authorization code for access token
         return TokenResponse(
             accessToken: "sampleAccessToken",
@@ -248,19 +450,97 @@ let credentialResponse = try await vciClient.requestCredentialFromTrustedIssuer(
             cNonceExpiresIn: 3600
         )
     },
-    getProofJwt: { credentialIssuer, cNonce, proofSigningAlgosSupported in
-        // Sign JWT with the private key as per proofSigningAlgosSupported
-        return "sampleProofJwt"
+    getProofJwt: { credentialIssuer, cNonce, proofSigningAlgorithmsSupported in
+        // Prepare payload for JWT
+        // Sign the JWT with the private key as per the proofSigningAlgorithmsSupported
+        let jwt = "sampleProofJwt"
+        return jwt
     },
-    downloadTimeoutInMillis: 10_000
+    downloadTimeoutInMillis: 10000
 )
 
-// Access the credential fields
-let credential = credentialResponse.credential  // This will be a JsonElement containing the credential data. eg - JsonPrimitive("omdk...t")
-let credentialConfigId = credentialResponse.credentialConfigurationId // eg - "DriversLicense"
-let credentialIssuer = credentialResponse.credentialIssuer // eg - "https://sample-issuer.com"
-
+// Consider the credential is a Driver's license credential (credential format `mso_mdoc`)
+let credentialResponse : CredentialResponse = try await vciClient.requestCredentialFromTrustedIssuer(
+    credentialIssuer: credentialIssuer,
+    credentialConfigurationId: credentialConfigurationId,
+    clientMetadata: clientMetadata,
+    authorizeUser: authorizeUser,
+    getTokenResponse: getTokenResponse,
+    getProofJwt: getProofJwt,
+    downloadTimeoutInMillis: downloadTimeoutInMillis
+)
+credentialResponse?.credential // This will contain the credential data
+credentialResponse?.credentialConfigurationId // eg - "DriversLicense"
+credentialResponse?.credentialIssuer // eg - "https://sample-issuer.com"
 ```
+
+###### Authorizations
+The `authorizations` parameter is a list of `Authorization` objects indicating the supported authorizations of the Wallet for the download flow. Currently, library supports two authorization flows - _Redirect To Web_ and _Presentation During Issuance_. Library exposes the supported authorization flows via class - `AuthorizationMethod`
+
+1. Redirect To Web (for Authorization flow)
+
+Redirect the user to the authorization endpoint (authorization server) in a web view or browser, and get the authorization response parameters back after successful authorization.
+
+**Parameters :**
+
+| Name        | Type                | Required | Default Value | Description                                                                                                                                                                         |
+|-------------|---------------------|----------|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| openWebPage | OpenWebPageCallback | Yes      | N/A           | Callback function to open the authorization endpoint in a web view or browser, and return the authorization response parameters (e.g., code, state) after successful authorization. |
+
+**Example usage**
+```swift
+AuthorizationMethod.redirectToWeb(
+    openWebPage: { authorizationEndpoint in
+        // Handle the user authorization logic here
+        // Open a web view or browser with the authorizationEndpoint
+        // Return the authorization response parameters (e.g., code, state)
+        let result: [String: Any] = openWebViewAndGetResult(authorizationEndpoint)
+        return result
+    }
+)
+```
+> Note: The Redirect to Web flow for an interactive authorization flow is exposed as an experimental API, and is expected to be improved in future releases.
+
+2. Presentation During Issuance
+
+Presentation During Issuance flow allows the Wallet to present a verifiable presentation to the Credential Issuer during the credential download process, which can be used by the issuer to verify certain claims about the user before issuing the credential. The authorization for the download here is presentation of another credential (or a verifiable presentation) instead of user-interaction-based authorization as in Redirect To Web flow.
+
+> Note: For Presentation During Issuance flow, this VCI client library internally uses [inji-openid4vp](https://github.com/inji/inji-openid4vp-ios-swift) library to construct the VP and handle the presentation exchange with the issuer.
+
+**Parameters :**
+
+| Name                             | Type                                     | Required | Default Value | Description                                                                                                                                                                                                                                                                                                                                                                                            |
+|----------------------------------|------------------------------------------|----------|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| selectCredentialsForPresentation | SelectCredentialsForPresentationCallback | Yes      | N/A           | Callback function to select credentials from the wallet to be presented to the issuer during issuance as per the Issuer's request. The callback will be invoked with a VP request, this VP request will be used by the Wallet to ask the user for selecting the credentials and then the selected credentials are returned                                                                             |
+| signVerifiablePresentation       | SignVerifiablePresentationCallback       | Yes      | N/A           | Callback function to sign the data which will be used for Verifiable Presentation construction. The callback will be invoked with the data to be signed, and the wallet needs to sign this data with the appropriate key and return the signature to the library.                                                                                                                                      |
+| ldpVpSignatureSuite              | String                                   | No       | nil           | The signature suite to be used for signing the VP in case of LDP VCs. It is mandatory to provide this parameter if the credential being requested is of format `ldp_vc`. The library will use this information to prepare the proof for the Verifiable Presentation accordingly. Supported values are - `Ed25519Signature2020`, `Ed25519Signature2018`, `JsonWebSignature2020` and `RSASignature2018`. |
+
+
+**Example usage**
+
+```swift
+AuthorizationMethod.presentationDuringIssuance(
+    selectCredentialsForPresentation: { presentationRequest in
+        // Handle the logic to select credentials from the wallet as per the presentation request
+        // Handle the logic for obtaining consent from the user for presenting the credentials to the issuer
+        let selectedCredentials: [String: [FormatType: [Any]]] = selectCredentials(presentationRequest)
+        return selectedCredentials
+    },
+    signVerifiablePresentation: { payload in
+        // Handle the logic to sign the data with the appropriate key as per the credential descriptor and signature suite
+        // From UnsignedVPTokenV2 use the data like format, holderKeyReference and signatureAlgorithm to identify the key to be used for signing and the algorithm to be used for signing the dataToSign, and then return the signature result back to the library
+        let signedData: [VPTokenSigningResultV2] = signDataForVP(payload)
+        // since the payload is a list of data to be signed for each credential, the result is also a list containing the signature result for each credential, and the library will take care of constructing the VP with the respective proof for each credential accordingly
+        // To avoid any confusion, the library will expect the implementation of this callback to return list of signature results corresponding to each credential in the same order as the payload, and the library will match the signature result with the respective credential based on the order of the payload list.
+        return signedData
+    },
+    ldpVpSignatureSuite: "Ed25519Signature2020"
+)
+```
+
+[//]: # (The branch in inji-wallet for pdi docs link is pointed to master intentionally to ensure that the latest documentation is always referred.)
+> For more details on the Presentation During Issuance flow and the expected implementation of the callbacks, please refer to the documentation of `inji-wallet` [here](https://github.com/inji/inji-wallet/blob/master/docs/presentation-during-issuance-support.md)
+
 
 ### 3.3 Request Credential
 - Method: `requestCredential`
@@ -270,52 +550,54 @@ let credentialIssuer = credentialResponse.credentialIssuer // eg - "https://samp
 
 #### Parameters
 
-| Name           | Type           | Required | Default Value | Description                                                                |
-|----------------|----------------|----------|---------------|----------------------------------------------------------------------------|
-| issuerMeta | IssuerMeta| Yes      | N/A           | Data object of the issuer details                                          |
-| proof      | Proof          | Yes      | N/A           | The proof used for making credential request. Supported proof types : JWT. |
-| accessToken    | String         | Yes      | N/A           | token issued by providers based on auth code                               |
+| Name        | Type       | Required | Default Value | Description                                                                |
+|-------------|------------|----------|---------------|----------------------------------------------------------------------------|
+| issuerMeta  | IssuerMeta | Yes      | N/A           | Data object of the issuer details                                          |
+| proof       | Proof      | Yes      | N/A           | The proof used for making credential request. Supported proof types : JWT. |
+| accessToken | String     | Yes      | N/A           | token issued by providers based on auth code                               |
 
 ###### Construction of issuerMetadata
 
 1. Format: `ldp_vc`
-```
-val issuerMetadata = IssuerMetadata(
-                        CREDENTIAL_AUDIENCE,
-                        CREDENTIAL_ENDPOINT, 
-                        DOWNLOAD_TIMEOUT, 
-                        CREDENTIAL_TYPE, 
-                        CredentialFormat.ldp_vc )
+```swift
+let issuerMetadata = IssuerMeta(
+    credentialAudience: CREDENTIAL_AUDIENCE,
+    credentialEndpoint: CREDENTIAL_ENDPOINT,
+    downloadTimeoutInMilliseconds: DOWNLOAD_TIMEOUT,
+    credentialType: CREDENTIAL_TYPE,
+    credentialFormat: .ldp_vc
+)
 ```
 2. Format: `mso_mdoc`
-```
-val issuerMetadata = IssuerMetadata(
-                        CREDENTIAL_AUDIENCE,
-                        CREDENTIAL_ENDPOINT, 
-                        DOWNLOAD_TIMEOUT, 
-                        DOC_TYPE,
-                        CLAIMS, 
-                        CredentialFormat.mso_mdoc )
+```swift
+let issuerMetadata = IssuerMeta(
+    credentialAudience: CREDENTIAL_AUDIENCE,
+    credentialEndpoint: CREDENTIAL_ENDPOINT,
+    downloadTimeoutInMilliseconds: DOWNLOAD_TIMEOUT,
+    credentialFormat: .mso_mdoc,
+    docType: DOC_TYPE,
+    claims: CLAIMS
+)
 ```
 
 3. Format: `vc+sd-jwt`
-```
-val issuerMetadata = IssuerMetadata(
-                        CREDENTIAL_AUDIENCE,
-                        CREDENTIAL_ENDPOINT,
-                        DOWNLOAD_TIMEOUT,
-                        VCT,
-                        CredentialFormat.vc_sd_jwt )
+```swift
+let issuerMetadata = IssuerMeta(
+    credentialAudience: CREDENTIAL_AUDIENCE,
+    credentialEndpoint: CREDENTIAL_ENDPOINT,
+    downloadTimeoutInMilliseconds: DOWNLOAD_TIMEOUT,
+    credentialFormat: .vc_sd_jwt
+)
 ```
 
 4. Format: `dc+sd-jwt`
-```
-val issuerMetadata = IssuerMetadata(
-                        CREDENTIAL_AUDIENCE,
-                        CREDENTIAL_ENDPOINT,
-                        DOWNLOAD_TIMEOUT,
-                        VCT,
-                        CredentialFormat.dc_sd_jwt )
+```swift
+let issuerMetadata = IssuerMeta(
+    credentialAudience: CREDENTIAL_AUDIENCE,
+    credentialEndpoint: CREDENTIAL_ENDPOINT,
+    downloadTimeoutInMilliseconds: DOWNLOAD_TIMEOUT,
+    credentialFormat: .dc_sd_jwt
+)
 ```
 #### Returns
 
@@ -323,27 +605,28 @@ An instance of `CredentialResponse` containing:
 
 | Name                      | Type        | Description                               |
 |---------------------------|-------------|-------------------------------------------|
-| credential                | JsonElement | The credential downloaded from the Issuer |
-| credentialConfigurationId | Null        | N/A                                       |
-| credentialIssuer          | Null        | N/A                                       |
+| credential                | AnyCodable  | The credential downloaded from the Issuer |
+| credentialConfigurationId | String?     | N/A                                       |
+| credentialIssuer          | String?     | N/A                                       |
 
 ##### Sample returned response
 
 ```swift
-val credentialResponse = try await vciClient.requestCredential(
-    issuerMeta = IssuerMetadata(
-                        CREDENTIAL_AUDIENCE,
-                        CREDENTIAL_ENDPOINT, 
-                        DOWNLOAD_TIMEOUT, 
-                        DOC_TYPE,
-                        CLAIMS, 
-                        CredentialFormat.MSO_MDOC ),
-    proof = JWTProof(jwtValue = "sampleProofJwt"),
-    accessToken = "sampleAccessToken"
+let credentialResponse = try await vciClient.requestCredential(
+    issuerMeta: IssuerMeta(
+        credentialAudience: CREDENTIAL_AUDIENCE,
+        credentialEndpoint: CREDENTIAL_ENDPOINT,
+        downloadTimeoutInMilliseconds: DOWNLOAD_TIMEOUT,
+        credentialFormat: .mso_mdoc,
+        docType: DOC_TYPE,
+        claims: CLAIMS
+    ),
+    proof: JWTProof(jwtValue: "sampleProofJwt"),
+    accessToken: "sampleAccessToken"
 )
-credentialResponse.credential // This will be a JsonElement containing the credential data. eg - JsonPrimitive("omdk...t")
-credentialResponse.credentialConfigurationId // This will be null
-credentialResponse.credentialIssuer // This will be null
+credentialResponse?.credential // This will contain the credential data
+credentialResponse?.credentialConfigurationId // This will be nil
+credentialResponse?.credentialIssuer // This will be nil
 ```
 
 ---
@@ -352,9 +635,11 @@ credentialResponse.credentialIssuer // This will be null
 
 The following methods are deprecated and will be removed in future releases. Please migrate to the suggested alternatives.
 
-| Method Name       | Description                                                                                     | Deprecated Since | Suggested Alternative                                                                                                                                                       |
-|-------------------|-------------------------------------------------------------------------------------------------|------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| requestCredential | Request for credential from the providers (credential issuer), and receive the credential back. | 0.4.0            | [requestCredentialByCredentialOffer()](#21-request-credential-using-credential-offer) or [requestCredentialFromTrustedIssuer()](#22-request-credential-from-trusted-issuer) |
+| Method Name                        | Description                                                                                                                                                              | Deprecated Since | Suggested Alternative                                                                                                                                                       |
+|------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| requestCredentialFromTrustedIssuer | Request for the download of Verifiable Credential through trusted flow has been improvised to accept different authorizations (web / presentation during issuance)       | 0.7.0            | [fetchCredentialFromTrustedIssuer](#fetchcredentialfromtrustedissuer)                                                                                                       |
+| requestCredentialByCredentialOffer | Request for download of Verifiable Credential through Credential Offer flow has been improvised to accept different authorizations (web / presentation during issuance). | 0.7.0            | [fetchCredentialUsingCredentialOffer](#fetchcredentialusingcredentialoffer)                                                                                                 |
+| requestCredential                  | Request for credential from the providers (credential issuer), and receive the credential back.                                                                          | 0.4.0            | [requestCredentialByCredentialOffer()](#31-request-credential-using-credential-offer) or [requestCredentialFromTrustedIssuer()](#32-request-credential-from-trusted-issuer) |
 
 ---
 
@@ -371,18 +656,19 @@ The following methods are deprecated and will be removed in future releases. Ple
 All exceptions thrown by the library are subclasses of `VCIClientException`.  
 They carry structured error codes like `VCI-001`, `VCI-002` etc., to help consumers identify and recover from failures.
 
-| Code    | Exception Type                          | Description                             |
-|---------|-----------------------------------------|-----------------------------------------|
-| VCI-001 | `AuthorizationServerDiscoveryException` | Failed to discover authorization server |
-| VCI-002 | `DownloadFailedException`               | Failed to download Credential issuer    |
-| VCI-003 | `InvalidAccessTokenException`           | Access token is invalid                 |
-| VCI-004 | `InvalidDataProvidedException`          | Required details not provided           |
-| VCI-005 | `InvalidPublicKeyException`             | Invalid public key passed metadata      |
-| VCI-006 | `NetworkRequestFailedException`         | Network request failed                  |
-| VCI-007 | `NetworkRequestTimeoutException`        | Network request timed-out               |
-| VCI-008 | `OfferFetchFailedException`             | Failed  to fetch credentialOffer        |
-| VCI-009 | `IssuerMetadataFetchException`          | Failed to fetch issuerMetadata          |
-
+| Code    | Exception Type                          | Description                                                                                              |
+|---------|-----------------------------------------|----------------------------------------------------------------------------------------------------------|
+| VCI-001 | `AuthorizationServerDiscoveryException` | Failed to discover authorization server                                                                  |
+| VCI-002 | `DownloadFailedException`               | Failed to download Credential issuer                                                                     |
+| VCI-003 | `InvalidAccessTokenException`           | Access token is invalid                                                                                  |
+| VCI-004 | `InvalidDataProvidedException`          | Required details not provided                                                                            |
+| VCI-005 | `InvalidPublicKeyException`             | Invalid public key passed metadata                                                                       |
+| VCI-006 | `NetworkRequestFailedException`         | Network request failed                                                                                   |
+| VCI-007 | `NetworkRequestTimeoutException`        | Network request timed-out                                                                                |
+| VCI-008 | `OfferFetchFailedException`             | Failed  to fetch credentialOffer                                                                         |
+| VCI-009 | `IssuerMetadataFetchException`          | Failed to fetch issuerMetadata                                                                           |
+| VCI-010 | `VCIClientException`                    | Unexpected error during the VCI process                                                                  |
+| VCI-011 | `InteractiveAuthorizationException`     | Failed to perform Interactive authorization (Presentation During Issuance / Redirect to Web interaction) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -141,20 +141,20 @@ let credentialConfigurationsSupported : [String: Any] = try await vciClient.getC
 - User-trust based credential download supported through onCheckIssuerTrust callback.
 - This method is the recommended way to request credential using credential offer.
 
-###### Parameters
+##### Parameters
 
-| Name                    | Type                     | Required | Default Value | Description                                                                                                                                                                               |
-|-------------------------|--------------------------|----------|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| credentialOffer         | String                   | Yes      | N/A           | Credential offer as embedded JSON or `credential_offer_uri`                                                                                                                               |
-| clientMetadata          | ClientMetadata           | Yes      | N/A           | Contains client ID and redirect URI                                                                                                                                                       |
-| getTxCode               | TxCodeCallback           | No       | N/A           | Optional callback function for TX Code (for Pre-Auth flows)                                                                                                                               |
-| authorizationMethods    | [AuthorizationMethod]    | Yes      | N/A           | Callback functions list to handle authorization and return the resultant authorization response (for Authorization flows) [click [here](#authorizations) for details about authorization] |
-| getTokenResponse        | TokenResponseCallback    | Yes      | N/A           | Callback function to exchange Authorization Grant with Access Token response                                                                                                              |
-| getProofJwt             | ProofJwtCallback         | Yes      | N/A           | Callback function to prepare proof-jwt for Credential Request                                                                                                                             |
-| onCheckIssuerTrust      | CheckIssuerTrustCallback | No       | nil           | Callback function to get user trust with the Credential Issuer                                                                                                                            |
-| downloadTimeoutInMillis | Int64                    | No       | 10000         | Download timeout set for Credential Request call with Credential Issuer (defaults to 10000 ms)                                                                                            |
+| Name                    | Type                     | Required | Default Value | Description                                                                                                                                                            |
+|-------------------------|--------------------------|----------|---------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| credentialOffer         | String                   | Yes      | N/A           | Credential offer as embedded JSON or `credential_offer_uri`                                                                                                            |
+| clientMetadata          | ClientMetadata           | Yes      | N/A           | Contains client ID and redirect URI                                                                                                                                    |
+| getTxCode               | TxCodeCallback           | No       | N/A           | Optional callback function for TX Code (for Pre-Auth flows)                                                                                                            |
+| authorizationMethods    | [AuthorizationMethod]    | Yes      | N/A           | Callback functions list to handle authorization and return the resultant authorization response (for Authorization flows) [see authorization details](#authorizations) |
+| getTokenResponse        | TokenResponseCallback    | Yes      | N/A           | Callback function to exchange Authorization Grant with Access Token response                                                                                           |
+| getProofJwt             | ProofJwtCallback         | Yes      | N/A           | Callback function to prepare proof-jwt for Credential Request                                                                                                          |
+| onCheckIssuerTrust      | CheckIssuerTrustCallback | No       | nil           | Callback function to get user trust with the Credential Issuer                                                                                                         |
+| downloadTimeoutInMillis | Int64                    | No       | 10000         | Download timeout set for Credential Request call with Credential Issuer (defaults to 10000 ms)                                                                         |
 
-###### Returns
+##### Returns
 
 An instance of `CredentialResponse` containing:
 
@@ -164,10 +164,10 @@ An instance of `CredentialResponse` containing:
 | credentialConfigurationId | String?    | The identifier of the respective supported credential from well-known response |
 | credentialIssuer          | String?    | URI of the Credential Issuer                                                   |
 
-###### Example usage
+##### Example usage
 
 ```swift
-let credentialResponse : CredentialResponse = try await vciClient.fetchCredentialUsingCredentialOffer(
+let credentialResponse: CredentialResponse? = try await vciClient.fetchCredentialUsingCredentialOffer(
     credentialOffer: "openid-credential-offer://?credential_offer_uri=https%3A%2F%2Fsample-issuer.com%2Fcredential-offer",
     clientMetadata: ClientMetadata(clientId: "sample-client-id", redirectUri: "https://sample-wallet.com/callback"),
     getTxCode: { inputMode, description, length in
@@ -210,7 +210,7 @@ let credentialResponse : CredentialResponse = try await vciClient.fetchCredentia
 )
 
 // Consider the credential is a Driver's license credential (credential format `mso_mdoc`)
-let credentialResponse = try await vciClient.fetchCredentialUsingCredentialOffer(
+let credentialResponse: CredentialResponse? = try await vciClient.fetchCredentialUsingCredentialOffer(
     credentialOffer: credentialOffer,
     clientMetadata: clientMetadata,
     getTxCode: getTxCode,
@@ -233,7 +233,7 @@ credentialResponse?.credentialIssuer // eg - "https://sample-issuer.com"
 - The library handles the PKCE flow internally.
 - User-trust based credential download supported through onCheckIssuerTrust callback.
 
-###### Parameters
+##### Parameters
 
 | Name                    | Type                     | Required | Default Value | Description                                                                                    |
 |-------------------------|--------------------------|----------|---------------|------------------------------------------------------------------------------------------------|
@@ -246,7 +246,7 @@ credentialResponse?.credentialIssuer // eg - "https://sample-issuer.com"
 | onCheckIssuerTrust      | CheckIssuerTrustCallback | No       | nil           | Callback function to get user trust with the Credential Issuer                                 |
 | downloadTimeoutInMillis | Int64                    | No       | 10000         | Download timeout set for Credential Request call with Credential Issuer (defaults to 10000 ms) |
 
-###### Returns
+##### Returns
 
 An instance of `CredentialResponse` containing:
 
@@ -256,10 +256,10 @@ An instance of `CredentialResponse` containing:
 | credentialConfigurationId | String?    | The identifier of the respective supported credential from well-known response |
 | credentialIssuer          | String?    | URI of the Credential Issuer                                                   |
 
-###### Example usage
+##### Example usage
 
 ```swift
-let credentialResponse : CredentialResponse = try await vciClient.requestCredentialByCredentialOffer(
+let credentialResponse: CredentialResponse? = try await vciClient.requestCredentialByCredentialOffer(
     credentialOffer: "openid-credential-offer://?credential_offer_uri=https%3A%2F%2Fsample-issuer.com%2Fcredential-offer",
     clientMetadata: ClientMetadata(clientId: "sample-client-id", redirectUri: "https://sample-wallet.com/callback"),
     getTxCode: { inputMode, description, length in
@@ -297,7 +297,7 @@ let credentialResponse : CredentialResponse = try await vciClient.requestCredent
 )
 
 // Consider the credential is a Driver's license credential (credential format `mso_mdoc`)
-let credentialResponse = try await vciClient.requestCredentialByCredentialOffer(
+let credentialResponse: CredentialResponse? = try await vciClient.requestCredentialByCredentialOffer(
     credentialOffer: credentialOffer,
     clientMetadata: clientMetadata,
     getTxCode: getTxCode,
@@ -321,15 +321,15 @@ credentialResponse?.credentialIssuer // eg - "https://sample-issuer.com"
 
 #### Parameters
 
-| Name                      | Type                  | Required | Default Value | Description                                                                                                                                                                               |
-|---------------------------|-----------------------|----------|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| credentialIssuer          | String                | Yes      | N/A           | URI of the Credential Issuer                                                                                                                                                              |
-| credentialConfigurationId | String                | Yes      | N/A           | Identifier of the respective supported credential from well-known response                                                                                                                |
-| clientMetadata            | ClientMetadata        | Yes      | N/A           | Contains client ID and redirect URI                                                                                                                                                       |
-| authorizationMethods      | [AuthorizationMethod] | Yes      | N/A           | Callback functions list to handle authorization and return the resultant authorization response (for Authorization flows) [click [here](#authorizations) for details about authorization] |
-| getTokenResponse          | TokenResponseCallback | Yes      | N/A           | Callback function to exchange Authorization Grant with Access Token response                                                                                                              |
-| getProofJwt               | ProofJwtCallback      | Yes      | N/A           | Callback function to prepare proof-jwt for Credential Request                                                                                                                             |
-| downloadTimeoutInMillis   | Int64                 | No       | 10000         | Download timeout set for Credential Request call with Credential Issuer (defaults to 10000 ms)                                                                                            |
+| Name                      | Type                  | Required | Default Value | Description                                                                                                                                                            |
+|---------------------------|-----------------------|----------|---------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| credentialIssuer          | String                | Yes      | N/A           | URI of the Credential Issuer                                                                                                                                           |
+| credentialConfigurationId | String                | Yes      | N/A           | Identifier of the respective supported credential from well-known response                                                                                             |
+| clientMetadata            | ClientMetadata        | Yes      | N/A           | Contains client ID and redirect URI                                                                                                                                    |
+| authorizationMethods      | [AuthorizationMethod] | Yes      | N/A           | Callback functions list to handle authorization and return the resultant authorization response (for Authorization flows) [see authorization details](#authorizations) |
+| getTokenResponse          | TokenResponseCallback | Yes      | N/A           | Callback function to exchange Authorization Grant with Access Token response                                                                                           |
+| getProofJwt               | ProofJwtCallback      | Yes      | N/A           | Callback function to prepare proof-jwt for Credential Request                                                                                                          |
+| downloadTimeoutInMillis   | Int64                 | No       | 10000         | Download timeout set for Credential Request call with Credential Issuer (defaults to 10000 ms)                                                                         |
 
 #### Returns
 
@@ -344,7 +344,7 @@ An instance of `CredentialResponse` containing:
 #### Example usage
 
 ```swift
-let credentialResponse = try await vciClient.fetchCredentialFromTrustedIssuer(
+let credentialResponse: CredentialResponse? = try await vciClient.fetchCredentialFromTrustedIssuer(
     credentialIssuer: "https://sample-issuer.com",
     credentialConfigurationId: "DriversLicense",
     clientMetadata: ClientMetadata(
@@ -382,7 +382,7 @@ let credentialResponse = try await vciClient.fetchCredentialFromTrustedIssuer(
 )
 
 // Consider the credential is a Driver's license credential (credential format `mso_mdoc`)
-let credentialResponse : CredentialResponse = try await vciClient.fetchCredentialFromTrustedIssuer(
+let credentialResponse: CredentialResponse? = try await vciClient.fetchCredentialFromTrustedIssuer(
     credentialIssuer: credentialIssuer,
     credentialConfigurationId: credentialConfigurationId,
     clientMetadata: clientMetadata,
@@ -427,7 +427,7 @@ An instance of `CredentialResponse` containing:
 #### Example usage
 
 ```swift
-let credentialResponse : CredentialResponse = try await vciClient.requestCredentialFromTrustedIssuer(
+let credentialResponse: CredentialResponse? = try await vciClient.requestCredentialFromTrustedIssuer(
     credentialIssuer: "https://sample-issuer.com",
     credentialConfigurationId: "DriversLicense",
     clientMetadata: ClientMetadata(
@@ -460,7 +460,7 @@ let credentialResponse : CredentialResponse = try await vciClient.requestCredent
 )
 
 // Consider the credential is a Driver's license credential (credential format `mso_mdoc`)
-let credentialResponse : CredentialResponse = try await vciClient.requestCredentialFromTrustedIssuer(
+let credentialResponse: CredentialResponse? = try await vciClient.requestCredentialFromTrustedIssuer(
     credentialIssuer: credentialIssuer,
     credentialConfigurationId: credentialConfigurationId,
     clientMetadata: clientMetadata,
@@ -474,7 +474,7 @@ credentialResponse?.credentialConfigurationId // eg - "DriversLicense"
 credentialResponse?.credentialIssuer // eg - "https://sample-issuer.com"
 ```
 
-###### Authorizations
+##### Authorizations
 The `authorizations` parameter is a list of `Authorization` objects indicating the supported authorizations of the Wallet for the download flow. Currently, library supports two authorization flows - _Redirect To Web_ and _Presentation During Issuance_. Library exposes the supported authorization flows via class - `AuthorizationMethod`
 
 1. Redirect To Web (for Authorization flow)
@@ -528,7 +528,7 @@ AuthorizationMethod.presentationDuringIssuance(
     },
     signVerifiablePresentation: { payload in
         // Handle the logic to sign the data with the appropriate key as per the credential descriptor and signature suite
-        // From UnsignedVPTokenV2 use the data like format, holderKeyReference and signatureAlgorithm to identify the key to be used for signing and the algorithm to be used for signing the dataToSign, and then return the signature result back to the library
+        // From UnsignedVPTokenV2 use the data like format, holderKeyReference and signatureAlgorithm to identify the key to be used for signing and the algorithm to be used for signing the dataToSign, and then return the signature result to the library
         let signedData: [VPTokenSigningResultV2] = signDataForVP(payload)
         // since the payload is a list of data to be signed for each credential, the result is also a list containing the signature result for each credential, and the library will take care of constructing the VP with the respective proof for each credential accordingly
         // To avoid any confusion, the library will expect the implementation of this callback to return list of signature results corresponding to each credential in the same order as the payload, and the library will match the signature result with the respective credential based on the order of the payload list.
@@ -539,7 +539,7 @@ AuthorizationMethod.presentationDuringIssuance(
 ```
 
 [//]: # (The branch in inji-wallet for pdi docs link is pointed to master intentionally to ensure that the latest documentation is always referred.)
-> For more details on the Presentation During Issuance flow and the expected implementation of the callbacks, please refer to the documentation of `inji-wallet` [here](https://github.com/inji/inji-wallet/blob/master/docs/presentation-during-issuance-support.md)
+> For more details on the Presentation During Issuance flow and the expected implementation of the callbacks, please refer to the [inji-wallet Presentation During Issuance documentation](https://github.com/inji/inji-wallet/blob/master/docs/presentation-during-issuance-support.md)
 
 
 ### 3.3 Request Credential
@@ -556,7 +556,7 @@ AuthorizationMethod.presentationDuringIssuance(
 | proof       | Proof      | Yes      | N/A           | The proof used for making credential request. Supported proof types : JWT. |
 | accessToken | String     | Yes      | N/A           | token issued by providers based on auth code                               |
 
-###### Construction of issuerMetadata
+##### Construction of issuerMetadata
 
 1. Format: `ldp_vc`
 ```swift
@@ -612,7 +612,7 @@ An instance of `CredentialResponse` containing:
 ##### Sample returned response
 
 ```swift
-let credentialResponse = try await vciClient.requestCredential(
+let credentialResponse: CredentialResponse? = try await vciClient.requestCredential(
     issuerMeta: IssuerMeta(
         credentialAudience: CREDENTIAL_AUDIENCE,
         credentialEndpoint: CREDENTIAL_ENDPOINT,
@@ -635,11 +635,11 @@ credentialResponse?.credentialIssuer // This will be nil
 
 The following methods are deprecated and will be removed in future releases. Please migrate to the suggested alternatives.
 
-| Method Name                        | Description                                                                                                                                                              | Deprecated Since | Suggested Alternative                                                                                                                                                       |
-|------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| requestCredentialFromTrustedIssuer | Request for the download of Verifiable Credential through trusted flow has been improvised to accept different authorizations (web / presentation during issuance)       | 0.7.0            | [fetchCredentialFromTrustedIssuer](#fetchcredentialfromtrustedissuer)                                                                                                       |
-| requestCredentialByCredentialOffer | Request for download of Verifiable Credential through Credential Offer flow has been improvised to accept different authorizations (web / presentation during issuance). | 0.7.0            | [fetchCredentialUsingCredentialOffer](#fetchcredentialusingcredentialoffer)                                                                                                 |
-| requestCredential                  | Request for credential from the providers (credential issuer), and receive the credential back.                                                                          | 0.4.0            | [requestCredentialByCredentialOffer()](#31-request-credential-using-credential-offer) or [requestCredentialFromTrustedIssuer()](#32-request-credential-from-trusted-issuer) |
+| Method Name                        | Description                                                                                                                                                              | Deprecated Since | Suggested Alternative                                                                                                                                    |
+|------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| requestCredentialFromTrustedIssuer | Request for the download of Verifiable Credential through trusted flow has been improvised to accept different authorizations (web / presentation during issuance)       | 0.7.0            | [fetchCredentialFromTrustedIssuer](#fetchcredentialfromtrustedissuer)                                                                                    |
+| requestCredentialByCredentialOffer | Request for download of Verifiable Credential through Credential Offer flow has been improvised to accept different authorizations (web / presentation during issuance). | 0.7.0            | [fetchCredentialUsingCredentialOffer](#fetchcredentialusingcredentialoffer)                                                                              |
+| requestCredential                  | Request for credential from the providers (credential issuer), and receive the credential back.                                                                          | 0.4.0            | [fetchCredentialUsingCredentialOffer()](#fetchcredentialusingcredentialoffer) or [fetchCredentialFromTrustedIssuer()](#fetchcredentialfromtrustedissuer) |
 
 ---
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded specification coverage for OpenID Verifiable Credential Issuance, added Kotlin/Swift library references, and bumped installation snippet.

* **New Features**
  * Added interactive authorization and presentation-during-issuance flows; samples updated to demonstrate new flows.

* **Bug Fixes / Improvements**
  * Improved credential response shapes and optional metadata fields for clearer handling.

* **Chores**
  * Public API surface updated with migration/deprecation guidance; added new error code (VCI-011) and updated error table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->