### PR TITLE
[INJIMOB-3701] add logic for missing_interaction_type

### DIFF
--- a/Sources/VCIClient/authorizationCodeFlow/AuthorizationCodeFlowService.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/AuthorizationCodeFlowService.swift
@@ -156,14 +156,23 @@ class AuthorizationCodeFlowService {
         let interactiveEndpoint = authorizationServerMetadata.interactiveAuthorizationEndpoint
 
         if let interactiveEndpoint {
-            return try await obtainAuthorizationCodeViaInteractiveAuthorizationEndpoint(
-                endpoint: interactiveEndpoint,
-                issuerMetadata: issuerMetadata,
-                clientMetadata: clientMetadata,
-                pkceSession: pkceSession,
-                credentialConfigurationId: credentialConfigurationId,
-                authorizationMethods: authorizationMethods
-            )
+            do {
+                return try await obtainAuthorizationCodeViaInteractiveAuthorizationEndpoint(
+                    endpoint: interactiveEndpoint,
+                    issuerMetadata: issuerMetadata,
+                    clientMetadata: clientMetadata,
+                    pkceSession: pkceSession,
+                    credentialConfigurationId: credentialConfigurationId,
+                    authorizationMethods: authorizationMethods
+                )
+            } catch let error as VCIClientException {
+                if error.serverErrorCode == Constants.MISSING_INTERACTION_TYPE_ERROR {
+                    return try await obtainAuthorizationCodeViaAuthorizationEndpoint(authorizationServerMetadata: authorizationServerMetadata, issuerMetadata: issuerMetadata, clientMetadata: clientMetadata, pkceSession: pkceSession, authorizationMethods: authorizationMethods)
+                } else {
+                    throw error
+                }
+            }
+
         } else {
             return try await obtainAuthorizationCodeViaAuthorizationEndpoint(
                 authorizationServerMetadata: authorizationServerMetadata,

--- a/Sources/VCIClient/constants/Constants.swift
+++ b/Sources/VCIClient/constants/Constants.swift
@@ -1,5 +1,7 @@
 public struct Constants {
     public static let defaultNetworkTimeoutInMillis: Int64 = 10_000
     static let credentialIssuerWellknownUriSuffix: String = "/.well-known/openid-credential-issuer"
+    
+    static let MISSING_INTERACTION_TYPE_ERROR = "missing_interaction_type"
 }
 

--- a/Tests/VCIClientTests/authorizationCodeFlow/AuthorizationCodeFlowServiceTests.swift
+++ b/Tests/VCIClientTests/authorizationCodeFlow/AuthorizationCodeFlowServiceTests.swift
@@ -1,4 +1,3 @@
-
 @testable import VCIClient
 import XCTest
 
@@ -30,7 +29,7 @@ final class AuthorizationCodeFlowServiceTests: XCTestCase {
                     _ in ["code": "mock-auth-code"]
                 })
             ],
-            getTokenResponse: {_ in TokenResponse(accessToken: "mock-token", tokenType: "Bearer")},
+            getTokenResponse: { _ in TokenResponse(accessToken: "mock-token", tokenType: "Bearer") },
             getProofJwt: { _, _, _ in "mock-jwt" },
             credentialConfigurationId: "vc1",
             proofSigningAlgorithmsSupportedSupported: ["rs256"]
@@ -49,7 +48,7 @@ final class AuthorizationCodeFlowServiceTests: XCTestCase {
             _ = try await service.requestCredentials(
                 issuerMetadata: IssuerMetadata.mock(),
                 clientMetadata: ClientMetadata(clientId: "client123", redirectUri: "app://redirect"),
-                getTokenResponse: {_ in TokenResponse(accessToken: "mock-token", tokenType: "Bearer")},
+                getTokenResponse: { _ in TokenResponse(accessToken: "mock-token", tokenType: "Bearer") },
                 getProofJwt: { _, _, _ in "mock-jwt" },
                 credentialConfigurationId: "vc1",
                 proofSigningAlgorithmsSupportedSupported: ["rs256"]
@@ -70,7 +69,7 @@ final class AuthorizationCodeFlowServiceTests: XCTestCase {
             _ = try await service.requestCredentials(
                 issuerMetadata: IssuerMetadata.mock(),
                 clientMetadata: ClientMetadata(clientId: "client123", redirectUri: "app://redirect"),
-                getTokenResponse: {_ in TokenResponse(accessToken: "mock-token", tokenType: "Bearer")},
+                getTokenResponse: { _ in TokenResponse(accessToken: "mock-token", tokenType: "Bearer") },
                 getProofJwt: { _, _, _ in "mock-jwt" },
                 credentialConfigurationId: "vc1",
                 proofSigningAlgorithmsSupportedSupported: ["rs256"]
@@ -131,6 +130,33 @@ final class AuthorizationCodeFlowServiceTests: XCTestCase {
             credentialConfigurationId: "vc1",
             proofSigningAlgorithmsSupportedSupported: ["rs256"],
             credentialOffer: offer
+        )
+
+        XCTAssertEqual(result.credential.value as? String, "mock-credential")
+    }
+
+    func test_interactiveAuth_missingInteractionType_shouldFallbackToAuthorizationEndpoint() async throws {
+        let resolver = MockAuthServerResolver()
+        resolver.mockInteractiveAuthorizationEndpoint = "https://auth.example.com/interactive"
+
+        let interactiveHandler = MockInteractiveAuthorizationHandler()
+        interactiveHandler.shouldThrowMissingInteractionType = true
+
+        let service = makeService(
+            resolver: resolver,
+            interactiveAuthHandler: interactiveHandler
+        )
+
+        let result = try await service.requestCredentials(
+            issuerMetadata: IssuerMetadata.mock(),
+            clientMetadata: ClientMetadata(clientId: "client123", redirectUri: "app://redirect"),
+            authorizationMethods: [
+                .redirectToWeb(openWebPage: { _ in ["code": "fallback-auth-code"] })
+            ],
+            getTokenResponse: { _ in TokenResponse(accessToken: "mock-token", tokenType: "Bearer") },
+            getProofJwt: { _, _, _ in "mock-jwt" },
+            credentialConfigurationId: "vc1",
+            proofSigningAlgorithmsSupportedSupported: ["rs256"]
         )
 
         XCTAssertEqual(result.credential.value as? String, "mock-credential")
@@ -234,6 +260,7 @@ final class AuthorizationCodeFlowServiceTests: XCTestCase {
     func test_requestCredentials_whenCredentialExecutorThrows_wrapsFailure() async {
         let executor = MockCredentialRequestExecutor()
         executor.errorToThrow = DownloadFailedException("credential failure")
+
         let service = makeService(executor: executor)
 
         do {
@@ -251,6 +278,30 @@ final class AuthorizationCodeFlowServiceTests: XCTestCase {
             XCTFail("Expected credential executor failure")
         } catch {
             XCTAssertTrue(error.localizedDescription.contains("credential failure"))
+        }
+    }
+
+    func test_credentialRequest_failure_shouldThrow() async {
+        let executor = MockCredentialRequestExecutor()
+        executor.shouldThrow = true
+
+        let service = makeService(executor: executor)
+
+        do {
+            _ = try await service.requestCredentials(
+                issuerMetadata: IssuerMetadata.mock(),
+                clientMetadata: ClientMetadata(clientId: "client123", redirectUri: "app://redirect"),
+                authorizationMethods: [
+                    .redirectToWeb(openWebPage: { _ in ["code": "mock-auth-code"] })
+                ],
+                getTokenResponse: { _ in TokenResponse(accessToken: "mock-token", tokenType: "Bearer") },
+                getProofJwt: { _, _, _ in "mock-jwt" },
+                credentialConfigurationId: "vc1",
+                proofSigningAlgorithmsSupportedSupported: ["rs256"]
+            )
+            XCTFail("Expected credential request failure")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.contains("credential"))
         }
     }
 

--- a/Tests/VCIClientTests/mocks/MockServices.swift
+++ b/Tests/VCIClientTests/mocks/MockServices.swift
@@ -76,6 +76,7 @@ final class MockTokenService: TokenService {
 final class MockCredentialRequestExecutor: CredentialRequestExecutor {
     var shouldReturnNil = false
     var errorToThrow: Error?
+    var shouldThrow: Bool = false
 
     init(shouldReturnNil: Bool = false) {
         self.shouldReturnNil = shouldReturnNil
@@ -93,7 +94,7 @@ final class MockCredentialRequestExecutor: CredentialRequestExecutor {
         if let errorToThrow {
             throw errorToThrow
         }
-
+        if shouldThrow { throw DownloadFailedException("test-error: credential request failed") }
         return CredentialResponse(credential: AnyCodable("mock-credential"), credentialIssuer: "mock-issuer", credentialConfigurationId: "mock-id")
     }
 }
@@ -250,6 +251,7 @@ class MockInteractiveAuthorizationHandler: InteractiveAuthorizationHandler {
         authSession: "dummy"
     )
     var errorToThrow: Error?
+    var shouldThrowMissingInteractionType: Bool = false
 
     override func handle(
         endpoint: String,
@@ -260,6 +262,9 @@ class MockInteractiveAuthorizationHandler: InteractiveAuthorizationHandler {
     ) async throws -> AuthorizationResponse {
         if let errorToThrow {
             throw errorToThrow
+        }
+        if shouldThrowMissingInteractionType {
+            throw DownloadFailedException(message: "dummy", serverErrorCode: "missing_interaction_type")
         }
         return responseToReturn
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authorization flow now falls back to an alternative authorization method when a specific interactive authorization error occurs, improving reliability and reducing failures for affected users.

* **Tests**
  * Added tests covering the new fallback behavior and credential request failure scenarios to ensure robust error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->