### PR TITLE
[INJIMOB-3793] add tests

### DIFF
--- a/Tests/VCIClientTests/VCIClientTests.swift
+++ b/Tests/VCIClientTests/VCIClientTests.swift
@@ -3,6 +3,102 @@ import XCTest
 @testable import VCIClient
 
 final class VCIClientTests: XCTestCase {
+    func testFetchCredentialUsingCredentialOffer_success() async throws {
+        let mockHandler = MockCredentialOfferHandler()
+        let client = VCIClient(
+            traceabilityId: "test",
+            credentialOfferHandler: mockHandler
+        )
+
+        let result = try await client.fetchCredentialUsingCredentialOffer(
+            credentialOffer: "mock-offer",
+            clientMetadata: ClientMetadata(clientId: "", redirectUri: ""),
+            getTxCode: { _, _, _ in "mock-tx-code" },
+            authorizationMethods: [
+                .redirectToWeb(openWebPage: { _ in ["code": "auth-code"] })
+            ],
+            getTokenResponse: { _ in TokenResponse(accessToken: "mock", tokenType: "Bearer") },
+            getProofJwt: { _, _, _ in "mock-jwt" }
+        )
+
+        XCTAssertNotNil(result)
+        XCTAssertTrue(mockHandler.didCallDownload)
+    }
+
+    func testFetchCredentialUsingCredentialOffer_failure() async {
+        let mockHandler = MockCredentialOfferHandler()
+        mockHandler.shouldThrow = true
+        let client = VCIClient(
+            traceabilityId: "test",
+            credentialOfferHandler: mockHandler
+        )
+
+        await assertThrowsVCIErrorContainingMessage(
+            expectedType: VCIClientException.self,
+            expectedCode: "VCI-010",
+            messageContains: "Simulated failure"
+        ) {
+            try await client.fetchCredentialUsingCredentialOffer(
+                credentialOffer: "mock-offer",
+                clientMetadata: ClientMetadata(clientId: "", redirectUri: ""),
+                getTxCode: { _, _, _ in "mock-tx-code" },
+                authorizationMethods: [
+                    .redirectToWeb(openWebPage: { _ in ["code": "auth-code"] })
+                ],
+                getTokenResponse: { _ in TokenResponse(accessToken: "mock", tokenType: "Bearer") },
+                getProofJwt: { _, _, _ in "mock-jwt" }
+            )
+        }
+    }
+
+    func testFetchCredentialFromTrustedIssuer_success() async throws {
+        let mockHandler = MockTrustedIssuerHandler()
+        let client = VCIClient(
+            traceabilityId: "test",
+            trustedIssuerFlowHandler: mockHandler
+        )
+
+        let result = try await client.fetchCredentialFromTrustedIssuer(
+            credentialIssuer: "mock",
+            credentialConfigurationId: "mock-id",
+            clientMetadata: ClientMetadata(clientId: "", redirectUri: ""),
+            getTokenResponse: { _ in TokenResponse(accessToken: "mock-token", tokenType: "Bearer") },
+            authorizationMethods: [
+                .redirectToWeb(openWebPage: { _ in ["code": "auth-code"] })
+            ],
+            getProofJwt: { _, _, _ in "mock-jwt" }
+        )
+
+        XCTAssertNotNil(result)
+        XCTAssertTrue(mockHandler.didCallDownload)
+    }
+
+    func testFetchCredentialFromTrustedIssuer_failure() async {
+        let mockHandler = MockTrustedIssuerHandler()
+        mockHandler.shouldThrow = true
+        let client = VCIClient(
+            traceabilityId: "test",
+            trustedIssuerFlowHandler: mockHandler
+        )
+
+        await assertThrowsVCIErrorContainingMessage(
+            expectedType: VCIClientException.self,
+            expectedCode: "VCI-010",
+            messageContains: "Simulated failure"
+        ) {
+            try await client.fetchCredentialFromTrustedIssuer(
+                credentialIssuer: "mock",
+                credentialConfigurationId: "mock-id",
+                clientMetadata: ClientMetadata(clientId: "", redirectUri: ""),
+                getTokenResponse: { _ in TokenResponse(accessToken: "mock-token", tokenType: "Bearer") },
+                authorizationMethods: [
+                    .redirectToWeb(openWebPage: { _ in ["code": "auth-code"] })
+                ],
+                getProofJwt: { _, _, _ in "mock-jwt" }
+            )
+        }
+    }
+
     func testRequestCredentialByCredentialOffer_success() async throws {
         let mockHandler = MockCredentialOfferHandler()
         let client = VCIClient(
@@ -268,5 +364,64 @@ final class VCIClientTests: XCTestCase {
                     credentialIssuer: "https://issuer.example.com"
                 )
             }
+        }
     }
-}
+
+    func testDeprecatedRequestCredential_failure_timeout() async {
+        let mockNetwork = MockNetworkManager()
+        mockNetwork.shouldThrowTimeout = true
+
+        let client = VCIClient(
+            traceabilityId: "test",
+            networkSession: mockNetwork
+        )
+
+        let issuerMeta = IssuerMeta(
+            credentialAudience: "aud",
+            credentialEndpoint: "https://example.com",
+            downloadTimeoutInMilliseconds: 5000,
+            credentialType: ["test"],
+            credentialFormat: .ldp_vc,
+            docType: nil,
+            claims: [:]
+        )
+
+        await assertThrowsVCIErrorContainingMessage(
+            expectedType: NetworkRequestTimeoutException.self,
+            messageContains: "Simulated timeout"
+        ) {
+            try await client.requestCredential(
+                issuerMeta: issuerMeta,
+                proof: JWTProof(jwt: "mock-jwt"),
+                accessToken: "token"
+            )
+        }
+    }
+
+    func testDeprecatedRequestCredential_emptyBody_returnsNil() async throws {
+        let mockNetwork = MockNetworkManager()
+        mockNetwork.responseBody = ""
+
+        let client = VCIClient(
+            traceabilityId: "test",
+            networkSession: mockNetwork
+        )
+
+        let issuerMeta = IssuerMeta(
+            credentialAudience: "aud",
+            credentialEndpoint: "https://example.com",
+            downloadTimeoutInMilliseconds: 5000,
+            credentialType: ["test"],
+            credentialFormat: .ldp_vc,
+            docType: nil,
+            claims: [:]
+        )
+
+        let result = try await client.requestCredential(
+            issuerMeta: issuerMeta,
+            proof: JWTProof(jwt: "mock-jwt"),
+            accessToken: "token"
+        )
+
+        XCTAssertNil(result)
+    }

--- a/Tests/VCIClientTests/authorizationCodeFlow/AuthorizationCodeFlowServiceTests.swift
+++ b/Tests/VCIClientTests/authorizationCodeFlow/AuthorizationCodeFlowServiceTests.swift
@@ -1,6 +1,7 @@
 
 @testable import VCIClient
 import XCTest
+
 final class AuthorizationCodeFlowServiceTests: XCTestCase {
     func makeService(
         resolver: AuthorizationServerResolver = MockAuthServerResolver(),
@@ -66,7 +67,7 @@ final class AuthorizationCodeFlowServiceTests: XCTestCase {
         let service = makeService(resolver: resolver)
 
         do {
-            let result = try await service.requestCredentials(
+            _ = try await service.requestCredentials(
                 issuerMetadata: IssuerMetadata.mock(),
                 clientMetadata: ClientMetadata(clientId: "client123", redirectUri: "app://redirect"),
                 getTokenResponse: {_ in TokenResponse(accessToken: "mock-token", tokenType: "Bearer")},
@@ -77,6 +78,224 @@ final class AuthorizationCodeFlowServiceTests: XCTestCase {
             XCTFail("Expected to throw due to missing token endpoint")
         } catch {
             XCTAssertTrue(error.localizedDescription.contains("Missing token endpoint"))
+        }
+    }
+
+    func test_requestCredentials_withInteractiveAuthorizationEndpoint_success() async throws {
+        let resolver = MockAuthServerResolver()
+        resolver.mockIssuer = "https://auth.example.com"
+        resolver.mockGrantTypesSupported = ["authorization_code"]
+        resolver.mockTokenEndpoint = "https://auth.example.com/token"
+        resolver.mcokAuthorizationEndpoint = nil
+        resolver.mockInteractiveAuthorizationEndpoint = "https://auth.example.com/interactive"
+
+        let interactiveHandler = MockInteractiveAuthorizationHandler()
+        interactiveHandler.responseToReturn = AuthorizationResponse(
+            authorizationCode: "interactive-code",
+            status: "success",
+            error: nil,
+            errorDescription: nil,
+            authSession: "session-1"
+        )
+
+        let service = makeService(
+            resolver: resolver,
+            interactiveAuthHandler: interactiveHandler
+        )
+
+        let metadata = IssuerMetadata(
+            credentialIssuer: "https://example.com",
+            credentialEndpoint: "https://example.com/credential",
+            credentialFormat: .ldp_vc,
+            authorizationServers: ["https://auth.example.com"]
+        )
+
+        let offer = CredentialOffer(
+            credentialIssuer: "https://example.com",
+            credentialConfigurationIds: ["vc1"],
+            grants: CredentialOfferGrants(
+                preAuthorizedGrant: nil,
+                authorizationCodeGrant: AuthorizationCodeGrant(
+                    issuerState: nil,
+                    authorizationServer: "https://auth.example.com"
+                )
+            )
+        )
+
+        let result = try await service.requestCredentials(
+            issuerMetadata: metadata,
+            clientMetadata: ClientMetadata(clientId: "client123", redirectUri: "app://redirect"),
+            authorizationMethods: [],
+            getTokenResponse: { _ in TokenResponse.mock() },
+            getProofJwt: { _, _, _ in "mock-jwt" },
+            credentialConfigurationId: "vc1",
+            proofSigningAlgorithmsSupportedSupported: ["rs256"],
+            credentialOffer: offer
+        )
+
+        XCTAssertEqual(result.credential.value as? String, "mock-credential")
+    }
+
+    func test_requestCredentials_whenInteractiveAuthorizationIsMissingType_wrapsFailure() async {
+        let resolver = MockAuthServerResolver()
+        resolver.mockIssuer = "https://auth.example.com"
+        resolver.mockGrantTypesSupported = ["authorization_code"]
+        resolver.mockTokenEndpoint = "https://auth.example.com/token"
+        resolver.mcokAuthorizationEndpoint = nil
+        resolver.mockInteractiveAuthorizationEndpoint = "https://auth.example.com/interactive"
+
+        let interactiveHandler = MockInteractiveAuthorizationHandler()
+        interactiveHandler.errorToThrow = InteractiveAuthorizationException(message: "missing_interaction_type")
+
+        let service = makeService(
+            resolver: resolver,
+            interactiveAuthHandler: interactiveHandler
+        )
+
+        let metadata = IssuerMetadata(
+            credentialIssuer: "https://example.com",
+            credentialEndpoint: "https://example.com/credential",
+            credentialFormat: .ldp_vc,
+            authorizationServers: ["https://auth.example.com"]
+        )
+
+        let offer = CredentialOffer(
+            credentialIssuer: "https://example.com",
+            credentialConfigurationIds: ["vc1"],
+            grants: CredentialOfferGrants(
+                preAuthorizedGrant: nil,
+                authorizationCodeGrant: AuthorizationCodeGrant(
+                    issuerState: nil,
+                    authorizationServer: "https://auth.example.com"
+                )
+            )
+        )
+
+        do {
+            _ = try await service.requestCredentials(
+                issuerMetadata: metadata,
+                clientMetadata: ClientMetadata(clientId: "client123", redirectUri: "app://redirect"),
+                authorizationMethods: [],
+                getTokenResponse: { _ in TokenResponse.mock() },
+                getProofJwt: { _, _, _ in "mock-jwt" },
+                credentialConfigurationId: "vc1",
+                proofSigningAlgorithmsSupportedSupported: ["rs256"],
+                credentialOffer: offer
+            )
+            XCTFail("Expected interactive authorization failure")
+        } catch let error as DownloadFailedException {
+            XCTAssertTrue(error.message.contains("Interactive authorization failed"))
+            XCTAssertTrue(error.message.contains("missing_interaction_type"))
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func test_requestCredentials_withoutAuthorizationMethod_shouldThrow() async {
+        let service = makeService()
+
+        do {
+            _ = try await service.requestCredentials(
+                issuerMetadata: IssuerMetadata.mock(),
+                clientMetadata: ClientMetadata(clientId: "client123", redirectUri: "app://redirect"),
+                authorizationMethods: [],
+                getTokenResponse: { _ in TokenResponse.mock() },
+                getProofJwt: { _, _, _ in "mock-jwt" },
+                credentialConfigurationId: "vc1",
+                proofSigningAlgorithmsSupportedSupported: ["rs256"]
+            )
+            XCTFail("Expected missing authorization method failure")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.contains("No authorization method available"))
+        }
+    }
+
+    func test_requestCredentials_whenProofCallbackThrows_wrapsFailure() async {
+        let service = makeService()
+
+        do {
+            _ = try await service.requestCredentials(
+                issuerMetadata: IssuerMetadata.mock(),
+                clientMetadata: ClientMetadata(clientId: "client123", redirectUri: "app://redirect"),
+                authorizationMethods: [
+                    .redirectToWeb(openWebPage: { _ in ["code": "mock-auth-code"] })
+                ],
+                getTokenResponse: { _ in TokenResponse.mock() },
+                getProofJwt: { _, _, _ in throw NSError(domain: "proof", code: 1) },
+                credentialConfigurationId: "vc1",
+                proofSigningAlgorithmsSupportedSupported: ["rs256"]
+            )
+            XCTFail("Expected proof callback failure")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.contains("Failed to obtain proof JWT"))
+        }
+    }
+
+    func test_requestCredentials_whenCredentialExecutorThrows_wrapsFailure() async {
+        let executor = MockCredentialRequestExecutor()
+        executor.errorToThrow = DownloadFailedException("credential failure")
+        let service = makeService(executor: executor)
+
+        do {
+            _ = try await service.requestCredentials(
+                issuerMetadata: IssuerMetadata.mock(),
+                clientMetadata: ClientMetadata(clientId: "client123", redirectUri: "app://redirect"),
+                authorizationMethods: [
+                    .redirectToWeb(openWebPage: { _ in ["code": "mock-auth-code"] })
+                ],
+                getTokenResponse: { _ in TokenResponse.mock() },
+                getProofJwt: { _, _, _ in "mock-jwt" },
+                credentialConfigurationId: "vc1",
+                proofSigningAlgorithmsSupportedSupported: ["rs256"]
+            )
+            XCTFail("Expected credential executor failure")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.contains("credential failure"))
+        }
+    }
+
+    func test_requestCredentials_whenTokenServiceThrowsWrapsFailure() async {
+        let tokenService = MockTokenService()
+        tokenService.authCodeErrorToThrow = InvalidDataProvidedException("token service rejected request")
+        let service = makeService(tokenService: tokenService)
+
+        do {
+            _ = try await service.requestCredentials(
+                issuerMetadata: IssuerMetadata.mock(),
+                clientMetadata: ClientMetadata(clientId: "client123", redirectUri: "app://redirect"),
+                authorizationMethods: [
+                    .redirectToWeb(openWebPage: { _ in ["code": "mock-auth-code"] })
+                ],
+                getTokenResponse: { _ in TokenResponse.mock() },
+                getProofJwt: { _, _, _ in "mock-jwt" },
+                credentialConfigurationId: "vc1",
+                proofSigningAlgorithmsSupportedSupported: ["rs256"]
+            )
+            XCTFail("Expected token service failure")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.contains("Failed to obtain access token via authorization code flow"))
+        }
+    }
+
+    func test_requestCredentials_whenCredentialResponseIsNil_shouldThrow() async {
+        let executor = MockCredentialRequestExecutor(shouldReturnNil: true)
+        let service = makeService(executor: executor)
+
+        do {
+            _ = try await service.requestCredentials(
+                issuerMetadata: IssuerMetadata.mock(),
+                clientMetadata: ClientMetadata(clientId: "client123", redirectUri: "app://redirect"),
+                authorizationMethods: [
+                    .redirectToWeb(openWebPage: { _ in ["code": "mock-auth-code"] })
+                ],
+                getTokenResponse: { _ in TokenResponse.mock() },
+                getProofJwt: { _, _, _ in "mock-jwt" },
+                credentialConfigurationId: "vc1",
+                proofSigningAlgorithmsSupportedSupported: ["rs256"]
+            )
+            XCTFail("Expected nil credential failure")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.contains("Credential request returned nil"))
         }
     }
 }

--- a/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationInteractionResponseTests.swift
+++ b/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationInteractionResponseTests.swift
@@ -1,0 +1,198 @@
+@testable import VCIClient
+import XCTest
+
+final class PresentationInteractionResponseTests: XCTestCase {
+    func testInitFromJson_requiresOpenId4VpRequest() {
+        XCTAssertThrowsError(
+            try PresentationInteractionResponse(
+                json: [
+                    "status": "require_interaction",
+                    "type": "openid4vp_presentation",
+                    "auth_session": "session-1",
+                ]
+            )
+        ) { error in
+            XCTAssertTrue(error is IllegalArgumentException)
+        }
+    }
+
+    func testDecoding_acceptsNestedDictionaryRequest() throws {
+        let data = """
+        {
+            "status": "require_interaction",
+            "type": "openid4vp_presentation",
+            "auth_session": "session-1",
+            "openid4vp_request": {
+                "response_type": "vp_token",
+                "response_mode": "iar-post",
+                "presentation_definition": {
+                    "id": "pd-1"
+                }
+            }
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder().decode(
+            PresentationInteractionResponse.self,
+            from: data
+        )
+
+        XCTAssertEqual(response.status, "require_interaction")
+        XCTAssertEqual(response.authSession, "session-1")
+        XCTAssertEqual(response.openid4vpRequest["response_type"] as? String, "vp_token")
+        XCTAssertEqual(
+            (response.openid4vpRequest["presentation_definition"] as? [String: Any])?["id"] as? String,
+            "pd-1"
+        )
+    }
+
+    func testValidate_acceptsUnsignedRequestWithSupportedResponseMode() throws {
+        let response = try PresentationInteractionResponse(
+            json: [
+                "status": "require_interaction",
+                "type": "openid4vp_presentation",
+                "auth_session": "session-1",
+                "openid4vp_request": [
+                    "response_type": "vp_token",
+                    "response_mode": "iar-post.jwt",
+                ],
+            ]
+        )
+
+        XCTAssertNoThrow(try response.validate())
+    }
+
+    func testValidate_acceptsSignedRequestWithSupportedResponseMode() throws {
+        let payload = #"{"response_mode":"iar-post"}"#
+        let encodedPayload = Data(payload.utf8).base64URLEncodedString()
+        let jwt = "header.\(encodedPayload).signature"
+
+        let response = try PresentationInteractionResponse(
+            json: [
+                "status": "require_interaction",
+                "type": "openid4vp_presentation",
+                "auth_session": "session-1",
+                "openid4vp_request": [
+                    "request": jwt,
+                ],
+            ]
+        )
+
+        XCTAssertNoThrow(try response.validate())
+    }
+
+    func testValidate_rejectsInvalidType() throws {
+        let response = try PresentationInteractionResponse(
+            json: [
+                "status": "require_interaction",
+                "type": "wrong_type",
+                "auth_session": "session-1",
+                "openid4vp_request": [
+                    "response_type": "vp_token",
+                    "response_mode": "iar-post",
+                ],
+            ]
+        )
+
+        XCTAssertThrowsError(try response.validate()) { error in
+            XCTAssertTrue(error is IllegalArgumentException)
+        }
+    }
+
+    func testValidate_rejectsMissingResponseTypeInUnsignedRequest() throws {
+        let response = try PresentationInteractionResponse(
+            json: [
+                "status": "require_interaction",
+                "type": "openid4vp_presentation",
+                "auth_session": "session-1",
+                "openid4vp_request": [
+                    "response_mode": "iar-post",
+                ],
+            ]
+        )
+
+        XCTAssertThrowsError(try response.validate())
+    }
+
+    func testValidate_rejectsInvalidResponseTypeInUnsignedRequest() throws {
+        let response = try PresentationInteractionResponse(
+            json: [
+                "status": "require_interaction",
+                "type": "openid4vp_presentation",
+                "auth_session": "session-1",
+                "openid4vp_request": [
+                    "response_type": "code",
+                    "response_mode": "iar-post",
+                ],
+            ]
+        )
+
+        XCTAssertThrowsError(try response.validate())
+    }
+
+    func testValidate_rejectsMissingResponseMode() throws {
+        let response = try PresentationInteractionResponse(
+            json: [
+                "status": "require_interaction",
+                "type": "openid4vp_presentation",
+                "auth_session": "session-1",
+                "openid4vp_request": [
+                    "response_type": "vp_token",
+                ],
+            ]
+        )
+
+        XCTAssertThrowsError(try response.validate()) { error in
+            XCTAssertTrue(error is IllegalArgumentException)
+        }
+    }
+
+    func testValidate_rejectsUnsupportedResponseMode() throws {
+        let response = try PresentationInteractionResponse(
+            json: [
+                "status": "require_interaction",
+                "type": "openid4vp_presentation",
+                "auth_session": "session-1",
+                "openid4vp_request": [
+                    "response_type": "vp_token",
+                    "response_mode": "direct_post",
+                ],
+            ]
+        )
+
+        XCTAssertThrowsError(try response.validate()) { error in
+            XCTAssertTrue(error is IllegalArgumentException)
+        }
+    }
+
+    func testValidate_rejectsMalformedSignedRequestJwt() throws {
+        let response = try PresentationInteractionResponse(
+            json: [
+                "status": "require_interaction",
+                "type": "openid4vp_presentation",
+                "auth_session": "session-1",
+                "openid4vp_request": [
+                    "request": "not-a-jwt",
+                ],
+            ]
+        )
+
+        XCTAssertThrowsError(try response.validate())
+    }
+
+    func testDecodeJwtPayload_rejectsNonDictionaryPayload() throws {
+        let payload = #"["not","a","dictionary"]"#
+        let encodedPayload = Data(payload.utf8).base64URLEncodedString()
+        let jwt = "header.\(encodedPayload).signature"
+        let response = try PresentationInteractionResponse(
+            json: [
+                "status": "require_interaction",
+                "type": "openid4vp_presentation",
+                "auth_session": "session-1",
+                "openid4vp_request": [:],
+            ]
+        )
+
+        XCTAssertThrowsError(try response.decodeJwtPayload(jwt: jwt))
+    }
+}

--- a/Tests/VCIClientTests/authorizationServer/AuthorizationServerDiscoveryServiceTests.swift
+++ b/Tests/VCIClientTests/authorizationServer/AuthorizationServerDiscoveryServiceTests.swift
@@ -1,0 +1,155 @@
+@testable import VCIClient
+import XCTest
+
+final class AuthorizationServerDiscoveryServiceTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        URLProtocol.registerClass(MockURLProtocol.self)
+    }
+
+    override func tearDown() {
+        URLProtocol.unregisterClass(MockURLProtocol.self)
+        MockURLProtocol.requestHandler = nil
+        super.tearDown()
+    }
+
+    func testDiscover_returnsOAuthMetadataWhenOAuthEndpointSucceeds() async throws {
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+
+            let data = """
+            {
+                "issuer": "https://issuer.example.com",
+                "token_endpoint": "https://issuer.example.com/token",
+                "authorization_endpoint": "https://issuer.example.com/auth"
+            }
+            """.data(using: .utf8)!
+
+            return (response, data)
+        }
+
+        let metadata = try await AuthorizationServerDiscoveryService().discover(
+            baseUrl: "https://issuer.example.com"
+        )
+
+        XCTAssertEqual(metadata.issuer, "https://issuer.example.com")
+        XCTAssertEqual(metadata.tokenEndpoint, "https://issuer.example.com/token")
+    }
+
+    func testDiscover_fallsBackToOpenIdWhenOAuthResponseIsBlank() async throws {
+        var requestedUrls: [String] = []
+
+        MockURLProtocol.requestHandler = { request in
+            requestedUrls.append(request.url!.absoluteString)
+
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+
+            if request.url!.absoluteString.contains("oauth-authorization-server") {
+                return (response, Data())
+            }
+
+            let data = """
+            {
+                "issuer": "https://issuer.example.com",
+                "token_endpoint": "https://issuer.example.com/token",
+                "authorization_endpoint": "https://issuer.example.com/auth"
+            }
+            """.data(using: .utf8)!
+
+            return (response, data)
+        }
+
+        let metadata = try await AuthorizationServerDiscoveryService().discover(
+            baseUrl: "https://issuer.example.com"
+        )
+
+        XCTAssertEqual(requestedUrls.count, 2)
+        XCTAssertTrue(requestedUrls[0].contains(".well-known/oauth-authorization-server"))
+        XCTAssertTrue(requestedUrls[1].contains(".well-known/openid-configuration"))
+        XCTAssertEqual(metadata.authorizationEndpoint, "https://issuer.example.com/auth")
+    }
+
+    func testDiscover_fallsBackToOpenIdWhenOAuthRequestFails() async throws {
+        MockURLProtocol.requestHandler = { request in
+            if request.url!.absoluteString.contains("oauth-authorization-server") {
+                throw URLError(.cannotFindHost)
+            }
+
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let data = """
+            {
+                "issuer": "https://issuer.example.com",
+                "token_endpoint": "https://issuer.example.com/token"
+            }
+            """.data(using: .utf8)!
+
+            return (response, data)
+        }
+
+        let metadata = try await AuthorizationServerDiscoveryService().discover(
+            baseUrl: "https://issuer.example.com"
+        )
+
+        XCTAssertEqual(metadata.tokenEndpoint, "https://issuer.example.com/token")
+    }
+
+    func testDiscover_throwsWhenBothDiscoveryEndpointsFail() async {
+        MockURLProtocol.requestHandler = { _ in
+            throw URLError(.cannotFindHost)
+        }
+
+        do {
+            _ = try await AuthorizationServerDiscoveryService().discover(
+                baseUrl: "https://issuer.example.com"
+            )
+            XCTFail("Expected discovery failure")
+        } catch let error as AutorizationServerDiscoveryException {
+            XCTAssertTrue(error.message.contains("Failed to discover authorization server metadata"))
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testDiscover_throwsWhenBothResponsesAreInvalid() async {
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+
+            if request.url!.absoluteString.contains("oauth-authorization-server") {
+                return (response, "not-json".data(using: .utf8)!)
+            }
+
+            return (response, Data("   ".utf8))
+        }
+
+        do {
+            _ = try await AuthorizationServerDiscoveryService().discover(
+                baseUrl: "https://issuer.example.com"
+            )
+            XCTFail("Expected discovery failure")
+        } catch let error as AutorizationServerDiscoveryException {
+            XCTAssertTrue(error.message.contains("Failed to discover authorization server metadata"))
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+}

--- a/Tests/VCIClientTests/mocks/MockServices.swift
+++ b/Tests/VCIClientTests/mocks/MockServices.swift
@@ -5,26 +5,29 @@ import Foundation
 // MARK: - Mock AuthServerResolver
 
 final class MockAuthServerResolver: AuthorizationServerResolver {
+    var mockIssuer: String = "mock-issuer"
     var mockTokenEndpoint: String? = "https://example.com/token"
     var mcokAuthorizationEndpoint: String? = "https://example.com/auth"
+    var mockInteractiveAuthorizationEndpoint: String?
+    var mockGrantTypesSupported: [String]? = nil
     override func resolveForPreAuth(issuerMetadata: IssuerMetadata, credentialOffer: CredentialOffer) async throws -> AuthorizationServerMetadata {
         return AuthorizationServerMetadata(
-            issuer: "mock-issuer",
-            grantTypesSupported: nil,
+            issuer: mockIssuer,
+            grantTypesSupported: mockGrantTypesSupported,
             tokenEndpoint: mockTokenEndpoint,
             authorizationEndpoint: nil,
-            interactiveAuthorizationEndpoint: nil
+            interactiveAuthorizationEndpoint: mockInteractiveAuthorizationEndpoint
         )
     }
 
     override func resolveForAuthCode(issuerMetadata: IssuerMetadata,
                                      credentialOffer: CredentialOffer? = nil) async throws -> AuthorizationServerMetadata {
         return AuthorizationServerMetadata(
-            issuer: "mock-issuer",
-            grantTypesSupported: nil,
+            issuer: mockIssuer,
+            grantTypesSupported: mockGrantTypesSupported,
             tokenEndpoint: mockTokenEndpoint,
             authorizationEndpoint: mcokAuthorizationEndpoint,
-            interactiveAuthorizationEndpoint: nil
+            interactiveAuthorizationEndpoint: mockInteractiveAuthorizationEndpoint
         )
     }
 }
@@ -32,6 +35,8 @@ final class MockAuthServerResolver: AuthorizationServerResolver {
 // MARK: - Mock TokenService
 
 final class MockTokenService: TokenService {
+    var authCodeErrorToThrow: Error?
+
     override func getAccessToken(getTokenResponse: @escaping TokenResponseCallback,
                                  tokenEndpoint: String,
                                  timeoutMillis: Int64 = Constants.defaultNetworkTimeoutInMillis,
@@ -53,6 +58,9 @@ final class MockTokenService: TokenService {
                                  clientId: String? = nil,
                                  redirectUri: String? = nil,
                                  codeVerifier: String? = nil) async throws -> TokenResponse {
+        if let authCodeErrorToThrow {
+            throw authCodeErrorToThrow
+        }
         return TokenResponse(
             accessToken: "mock-access-token",
             tokenType: "Bearer",
@@ -67,6 +75,7 @@ final class MockTokenService: TokenService {
 
 final class MockCredentialRequestExecutor: CredentialRequestExecutor {
     var shouldReturnNil = false
+    var errorToThrow: Error?
 
     init(shouldReturnNil: Bool = false) {
         self.shouldReturnNil = shouldReturnNil
@@ -81,6 +90,9 @@ final class MockCredentialRequestExecutor: CredentialRequestExecutor {
         session: NetworkManager = NetworkManager.shared
     ) async throws -> CredentialResponse? {
         if shouldReturnNil { return nil }
+        if let errorToThrow {
+            throw errorToThrow
+        }
 
         return CredentialResponse(credential: AnyCodable("mock-credential"), credentialIssuer: "mock-issuer", credentialConfigurationId: "mock-id")
     }
@@ -230,14 +242,26 @@ class MockValidCredentialRequest: CredentialRequestProtocol {
 }
 
 class MockInteractiveAuthorizationHandler: InteractiveAuthorizationHandler {
-    func handle(
+    var responseToReturn = AuthorizationResponse(
+        authorizationCode: "dummy",
+        status: "success",
+        error: nil,
+        errorDescription: nil,
+        authSession: "dummy"
+    )
+    var errorToThrow: Error?
+
+    override func handle(
         endpoint: String,
         clientMetadata: ClientMetadata,
         credentialConfigurationId: String,
         authorizationMethods: [AuthorizationMethod],
         pkceSession: PKCESessionManager.PKCESession
-    ) -> AuthorizationResponse {
-        return AuthorizationResponse(authorizationCode: "dummy", status: "success", error: nil, errorDescription: nil, authSession: "dummy")
+    ) async throws -> AuthorizationResponse {
+        if let errorToThrow {
+            throw errorToThrow
+        }
+        return responseToReturn
     }
 }
 

--- a/Tests/VCIClientTests/networkManager/NetworkManagerTests.swift
+++ b/Tests/VCIClientTests/networkManager/NetworkManagerTests.swift
@@ -2,6 +2,35 @@
 import XCTest
 
 final class NetworkManagerTests: XCTestCase {
+    private func requestBodyData(from request: URLRequest) -> Data? {
+        if let body = request.httpBody {
+            return body
+        }
+
+        guard let stream = request.httpBodyStream else {
+            return nil
+        }
+
+        stream.open()
+        defer { stream.close() }
+
+        var data = Data()
+        let bufferSize = 1024
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+
+        while stream.hasBytesAvailable {
+            let read = stream.read(buffer, maxLength: bufferSize)
+            if read > 0 {
+                data.append(buffer, count: read)
+            } else {
+                break
+            }
+        }
+
+        return data
+    }
+
     override func setUp() {
         super.setUp()
         URLProtocol.registerClass(MockURLProtocol.self)
@@ -85,6 +114,156 @@ final class NetworkManagerTests: XCTestCase {
             XCTFail("Expected timeout error")
         } catch {
             XCTAssertTrue(error is NetworkRequestTimeoutException)
+        }
+    }
+
+    func testSendRequest_postFormUrlEncoded_encodesBodyAndHeaders() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(
+                request.value(forHTTPHeaderField: "Content-Type"),
+                "application/x-www-form-urlencoded"
+            )
+            let body = try XCTUnwrap(
+                String(data: self.requestBodyData(from: request) ?? Data(), encoding: .utf8)
+            )
+            let params = Set(body.split(separator: "&").map(String.init))
+            XCTAssertEqual(
+                params,
+                Set([
+                    "name=John%20Doe",
+                    "city=New%20York",
+                ])
+            )
+
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["X-Test": "yes"]
+            )!
+
+            return (response, #"{"status":"ok"}"#.data(using: .utf8)!)
+        }
+
+        let response = try await NetworkManager.shared.sendRequest(
+            url: "https://example.com/form",
+            method: .post,
+            headers: ["Content-Type": "application/x-www-form-urlencoded"],
+            bodyParams: [
+                "name": "John Doe",
+                "city": "New York",
+            ]
+        )
+
+        XCTAssertEqual(response.body, #"{"status":"ok"}"#)
+        XCTAssertEqual(response.headers?["X-Test"] as? String, "yes")
+    }
+
+    func testSendRequest_postJson_encodesBodyAsJson() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "POST")
+
+            let json = try XCTUnwrap(self.requestBodyData(from: request))
+            let object = try XCTUnwrap(
+                try JSONSerialization.jsonObject(with: json) as? [String: String]
+            )
+
+            XCTAssertEqual(object["scope"], "openid")
+            XCTAssertEqual(object["grant_type"], "authorization_code")
+
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+
+            return (response, #"{"status":"ok"}"#.data(using: .utf8)!)
+        }
+
+        _ = try await NetworkManager.shared.sendRequest(
+            url: "https://example.com/json",
+            method: .post,
+            headers: ["Content-Type": "application/json"],
+            bodyParams: [
+                "scope": "openid",
+                "grant_type": "authorization_code",
+            ]
+        )
+    }
+
+    func testSendRequestV2_postAssignsRawBody() async throws {
+        let expectedBody = Data("raw-body".utf8)
+
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(self.requestBodyData(from: request), expectedBody)
+
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+
+            return (response, #"{"status":"ok"}"#.data(using: .utf8)!)
+        }
+
+        _ = try await NetworkManager.shared.sendRequestV2(
+            url: "https://example.com/raw",
+            method: .post,
+            body: expectedBody
+        )
+    }
+
+    func testSendRequestV2_getDoesNotAssignBody() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertNil(request.httpBody)
+
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+
+            return (response, Data())
+        }
+
+        _ = try await NetworkManager.shared.sendRequestV2(
+            url: "https://example.com/raw",
+            method: .get,
+            body: Data("ignored".utf8)
+        )
+    }
+
+    func testSendRequestHTTPError_parsesServerErrorPayload() async {
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 400,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+
+            let data = #"{"error":"invalid_request","error_description":"missing proof"}"#.data(using: .utf8)!
+
+            return (response, data)
+        }
+
+        do {
+            _ = try await NetworkManager.shared.sendRequest(
+                url: "https://example.com",
+                method: .get
+            )
+            XCTFail("Expected HTTP error")
+        } catch let error as NetworkRequestFailedException {
+            XCTAssertEqual(error.serverErrorCode, "invalid_request")
+            XCTAssertEqual(error.serverErrorDescription, "missing proof")
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
         }
     }
 }


### PR DESCRIPTION
## Summary
- add focused tests for VCIClient, authorization code flow, network manager, discovery service, and presentation response validation
- increase package line coverage from 75.31% to 81.83%
- keep test additions aligned with the existing XCTest style and behavior-driven coverage gaps

## Verification
- swift test --enable-code-coverage
- xcrun llvm-cov report .build/arm64-apple-macosx/debug/VCIClientPackageTests.xctest/Contents/MacOS/VCIClientPackageTests -instr-profile .build/arm64-apple-macosx/debug/codecov/default.profdata Sources/VCIClient/* Sources/VCIClient/**/*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for credential acquisition flows, authorization code flows, and network request handling with comprehensive success and failure path validation
  * Added new test suites for authorization server discovery, presentation interaction responses, and network request behaviors
  * Enhanced mock services with configurable properties to enable more flexible and realistic testing scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->