### PR TITLE
fix(ios): allow missing/empty  cnonce in draft13 flow

### DIFF
--- a/Sources/VCIClient/nonce/NonceService.swift
+++ b/Sources/VCIClient/nonce/NonceService.swift
@@ -11,7 +11,7 @@ class NonceService {
         if let cNonce = tokenResponse.cNonce, !cNonce.isEmpty {
             return cNonce
         }
-        throw DownloadFailedException("No c_nonce in token response")
+        return nil
     }
 
     func fetchNonce(

--- a/Tests/VCIClientTests/authorizationCodeFlow/AuthorizationCodeFlowServiceTests.swift
+++ b/Tests/VCIClientTests/authorizationCodeFlow/AuthorizationCodeFlowServiceTests.swift
@@ -29,7 +29,7 @@ final class AuthorizationCodeFlowServiceTests: XCTestCase {
             authorizationMethods: [
                 .redirectToWeb(openWebPage: {
                     _ in ["code": "mock-auth-code"]
-                })
+                }),
             ],
             getTokenResponse: { _ in TokenResponse(accessToken: "mock-token", tokenType: "Bearer") },
             getProofJwt: { _, _, _ in "mock-jwt" },
@@ -55,7 +55,7 @@ final class AuthorizationCodeFlowServiceTests: XCTestCase {
             ),
             clientMetadata: ClientMetadata(clientId: "client123", redirectUri: "app://redirect"),
             authorizationMethods: [
-                .redirectToWeb(openWebPage: { _ in ["code": "mock-auth-code"] })
+                .redirectToWeb(openWebPage: { _ in ["code": "mock-auth-code"] }),
             ],
             getTokenResponse: { _ in TokenResponse(accessToken: "mock-token", tokenType: "Bearer") },
             getProofs: { _, nonce, _ in
@@ -68,35 +68,6 @@ final class AuthorizationCodeFlowServiceTests: XCTestCase {
 
         XCTAssertEqual(capturedNonce, "nonce-v1")
         XCTAssertEqual(result.credentials?.count, 1)
-    }
-
-    func test_requestCredentialsDraft13_withoutCNonce_shouldThrow() async {
-        let tokenService = MockTokenService()
-        tokenService.authCodeTokenResponse = TokenResponse(
-            accessToken: "mock-access-token",
-            tokenType: "Bearer",
-            expiresIn: 3600,
-            cNonce: "",
-            cNonceExpiresIn: 0
-        )
-        let service = makeService(tokenService: tokenService)
-
-        await assertThrowsVCIErrorContainingMessage(
-            expectedType: DownloadFailedException.self,
-            messageContains: "No c_nonce in token response"
-        ) {
-            try await service.requestCredentialsDraft13(
-                issuerMetadata: IssuerMetadata.mock(),
-                clientMetadata: ClientMetadata(clientId: "client123", redirectUri: "app://redirect"),
-                authorizationMethods: [
-                    .redirectToWeb(openWebPage: { _ in ["code": "mock-auth-code"] })
-                ],
-                getTokenResponse: { _ in TokenResponse.mock() },
-                getProofJwt: { _, _, _ in "mock-jwt" },
-                credentialConfigurationId: "vc1",
-                proofSigningAlgorithmsSupported: ["rs256"]
-            )
-        }
     }
 
     func test_missingAuthorizationEndpoint_shouldThrow() async {
@@ -212,7 +183,7 @@ final class AuthorizationCodeFlowServiceTests: XCTestCase {
             issuerMetadata: IssuerMetadata.mock(),
             clientMetadata: ClientMetadata(clientId: "client123", redirectUri: "app://redirect"),
             authorizationMethods: [
-                .redirectToWeb(openWebPage: { _ in ["code": "fallback-auth-code"] })
+                .redirectToWeb(openWebPage: { _ in ["code": "fallback-auth-code"] }),
             ],
             getTokenResponse: { _ in TokenResponse(accessToken: "mock-token", tokenType: "Bearer") },
             getProofJwt: { _, _, _ in "mock-jwt" },
@@ -305,7 +276,7 @@ final class AuthorizationCodeFlowServiceTests: XCTestCase {
                 issuerMetadata: IssuerMetadata.mock(),
                 clientMetadata: ClientMetadata(clientId: "client123", redirectUri: "app://redirect"),
                 authorizationMethods: [
-                    .redirectToWeb(openWebPage: { _ in ["code": "mock-auth-code"] })
+                    .redirectToWeb(openWebPage: { _ in ["code": "mock-auth-code"] }),
                 ],
                 getTokenResponse: { _ in TokenResponse.mock() },
                 getProofJwt: { _, _, _ in throw NSError(domain: "proof", code: 1) },
@@ -329,7 +300,7 @@ final class AuthorizationCodeFlowServiceTests: XCTestCase {
                 issuerMetadata: IssuerMetadata.mock(),
                 clientMetadata: ClientMetadata(clientId: "client123", redirectUri: "app://redirect"),
                 authorizationMethods: [
-                    .redirectToWeb(openWebPage: { _ in ["code": "mock-auth-code"] })
+                    .redirectToWeb(openWebPage: { _ in ["code": "mock-auth-code"] }),
                 ],
                 getTokenResponse: { _ in TokenResponse.mock() },
                 getProofJwt: { _, _, _ in "mock-jwt" },
@@ -353,7 +324,7 @@ final class AuthorizationCodeFlowServiceTests: XCTestCase {
                 issuerMetadata: IssuerMetadata.mock(),
                 clientMetadata: ClientMetadata(clientId: "client123", redirectUri: "app://redirect"),
                 authorizationMethods: [
-                    .redirectToWeb(openWebPage: { _ in ["code": "mock-auth-code"] })
+                    .redirectToWeb(openWebPage: { _ in ["code": "mock-auth-code"] }),
                 ],
                 getTokenResponse: { _ in TokenResponse(accessToken: "mock-token", tokenType: "Bearer") },
                 getProofJwt: { _, _, _ in "mock-jwt" },
@@ -376,7 +347,7 @@ final class AuthorizationCodeFlowServiceTests: XCTestCase {
                 issuerMetadata: IssuerMetadata.mock(),
                 clientMetadata: ClientMetadata(clientId: "client123", redirectUri: "app://redirect"),
                 authorizationMethods: [
-                    .redirectToWeb(openWebPage: { _ in ["code": "mock-auth-code"] })
+                    .redirectToWeb(openWebPage: { _ in ["code": "mock-auth-code"] }),
                 ],
                 getTokenResponse: { _ in TokenResponse.mock() },
                 getProofJwt: { _, _, _ in "mock-jwt" },
@@ -398,7 +369,7 @@ final class AuthorizationCodeFlowServiceTests: XCTestCase {
                 issuerMetadata: IssuerMetadata.mock(),
                 clientMetadata: ClientMetadata(clientId: "client123", redirectUri: "app://redirect"),
                 authorizationMethods: [
-                    .redirectToWeb(openWebPage: { _ in ["code": "mock-auth-code"] })
+                    .redirectToWeb(openWebPage: { _ in ["code": "mock-auth-code"] }),
                 ],
                 getTokenResponse: { _ in TokenResponse.mock() },
                 getProofJwt: { _, _, _ in "mock-jwt" },

--- a/Tests/VCIClientTests/preAuthFlow/PreAuthFlowServiceTests.swift
+++ b/Tests/VCIClientTests/preAuthFlow/PreAuthFlowServiceTests.swift
@@ -63,33 +63,6 @@ final class PreAuthFlowServiceTests: XCTestCase {
         XCTAssertEqual(result.credentials?.count, 1)
     }
 
-    func test_requestCredentialsDraft13_missingCNonce_shouldThrow() async {
-        let tokenService = MockTokenService()
-        tokenService.preAuthTokenResponse = TokenResponse(
-            accessToken: "mock-access-token",
-            tokenType: "Bearer",
-            expiresIn: 3600,
-            cNonce: "",
-            cNonceExpiresIn: 0
-        )
-        let service = makeService(tokenService: tokenService)
-
-        await assertThrowsVCIErrorContainingMessage(
-            expectedType: DownloadFailedException.self,
-            messageContains: "No c_nonce in token response"
-        ) {
-            try await service.requestCredentialsDraft13(
-                issuerMetadata: IssuerMetadata.mock(),
-                credentialOffer: CredentialOffer.mockWithTxCodeRequired(),
-                getTokenResponse: { _ in TokenResponse(accessToken: "mock", tokenType: "Bearer") },
-                getProofJwt: { _, _, _ in "jwt-mock" },
-                credentialConfigurationId: "mock-id",
-                proofSigningAlgorithmsSupported: [],
-                getTxCode: { _, _, _ in "tx123" }
-            )
-        }
-    }
-
     func test_requestCredentials_missingTokenEndpoint_shouldThrow() async {
         let resolver = MockAuthServerResolver()
         resolver.mockTokenEndpoint = nil


### PR DESCRIPTION
Fixes https://github.com/inji/inji-wallet/issues/2290

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in token response processing to better manage cases where critical nonce values are missing or empty.

* **Tests**
  * Updated test suite to reflect improvements in error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->