### PR TITLE
chore: update OVP library version

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -42,7 +42,7 @@
       "location" : "https://github.com/tw-mosip/inji-openid4vp-ios-swift",
       "state" : {
         "branch" : "2287-dcql-query-support",
-        "revision" : "7ac59007af8b71cdf641b3b6b784511440f6ffc5"
+        "revision" : "8ce08af1764abb9232d544e4c28ecae3f1cd5b58"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -39,10 +39,10 @@
     {
       "identity" : "inji-openid4vp-ios-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tw-mosip/inji-openid4vp-ios-swift",
+      "location" : "https://github.com/inji/inji-openid4vp-ios-swift",
       "state" : {
-        "branch" : "2287-dcql-query-support",
-        "revision" : "8ce08af1764abb9232d544e4c28ecae3f1cd5b58"
+        "branch" : "develop",
+        "revision" : "921fcc6e95e3cc4ffcd59936e2486950049e4fc4"
       }
     },
     {
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
-        "version" : "1.7.0"
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -39,10 +39,10 @@
     {
       "identity" : "inji-openid4vp-ios-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/inji/inji-openid4vp-ios-swift",
+      "location" : "https://github.com/tw-mosip/inji-openid4vp-ios-swift",
       "state" : {
-        "revision" : "38e12ead6805da5cc2e214f065a5451f699e91dc",
-        "version" : "0.7.0"
+        "branch" : "2288",
+        "revision" : "241eaca99006f92af49c326185fc72adb9071e9d"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tw-mosip/inji-openid4vp-ios-swift",
       "state" : {
-        "branch" : "2288",
-        "revision" : "241eaca99006f92af49c326185fc72adb9071e9d"
+        "branch" : "2287-dcql-query-support",
+        "revision" : "7ac59007af8b71cdf641b3b6b784511440f6ffc5"
       }
     },
     {
@@ -52,6 +52,15 @@
       "state" : {
         "revision" : "57fe5a03c83feaf73a84b23c02e641f86482e313",
         "version" : "4.0.2"
+      }
+    },
+    {
+      "identity" : "multiformatskit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ATProtoKit/MultiformatsKit.git",
+      "state" : {
+        "revision" : "cfb8003e2d6bd8c3520a1b38cdbef8e757876e6d",
+        "version" : "0.3.1"
       }
     },
     {
@@ -70,6 +79,24 @@
       "state" : {
         "revision" : "e325083424688055363bbfcb7f1a440d7d7a1bae",
         "version" : "1.2.2"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version" : "3.15.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/valpackett/SwiftCBOR", .upToNextMajor(from: "0.5.0")),
-        .package(url: "https://github.com/tw-mosip/inji-openid4vp-ios-swift", branch: "2287-dcql-query-support")
+        .package(url: "https://github.com/inji/inji-openid4vp-ios-swift", branch: "develop")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/valpackett/SwiftCBOR", .upToNextMajor(from: "0.5.0")),
-        .package(url: "https://github.com/inji/inji-openid4vp-ios-swift", .upToNextMajor(from: "0.7.0"))
+        .package(url: "https://github.com/tw-mosip/inji-openid4vp-ios-swift", branch: "2288")
     ],
     targets: [
         .target(
@@ -42,3 +42,4 @@ let package = Package(
             )
     ]
 )
+

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/valpackett/SwiftCBOR", .upToNextMajor(from: "0.5.0")),
-        .package(url: "https://github.com/tw-mosip/inji-openid4vp-ios-swift", branch: "2288")
+        .package(url: "https://github.com/tw-mosip/inji-openid4vp-ios-swift", branch: "2287-dcql-query-support")
     ],
     targets: [
         .target(

--- a/Sources/OpenID4VPBridge/CredentialBridge.swift
+++ b/Sources/OpenID4VPBridge/CredentialBridge.swift
@@ -1,0 +1,5 @@
+import OpenID4VP
+
+public typealias OpenID4VPCredential = Credential
+
+

--- a/Sources/VCIClient/authorizationCodeFlow/AuthorizationMethod.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/AuthorizationMethod.swift
@@ -1,6 +1,5 @@
 import Foundation
 import OpenID4VP
-import OpenID4VPBridge
 
 public enum AuthorizationMethod {
     case redirectToWeb(
@@ -9,6 +8,7 @@ public enum AuthorizationMethod {
 
     case presentationDuringIssuance(
         jsonLdCanonicalizer: JsonLdCanonicalizerCallback? = nil,
+        openid4vpWalletConfig: WalletConfig = WalletConfig(),
         selectCredentialsForPresentation: SelectCredentialsForPresentationCallback,
         signVerifiablePresentation: SignVerifiablePresentationCallback
     )

--- a/Sources/VCIClient/authorizationCodeFlow/AuthorizationMethod.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/AuthorizationMethod.swift
@@ -8,9 +8,9 @@ public enum AuthorizationMethod {
     )
 
     case presentationDuringIssuance(
+        jsonLdCanonicalizer: JsonLdCanonicalizerCallback? = nil,
         selectCredentialsForPresentation: SelectCredentialsForPresentationCallback,
-        signVerifiablePresentation: SignVerifiablePresentationCallback,
-        ldpVpSignatureSuite: String? = nil
+        signVerifiablePresentation: SignVerifiablePresentationCallback
     )
 
     var type: InteractionType {

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/Handler/InteractiveAuthorizationHandler.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/Handler/InteractiveAuthorizationHandler.swift
@@ -144,15 +144,15 @@ class InteractiveAuthorizationHandler {
         }
         
         guard
-            case let .presentationDuringIssuance(selectCredentialsForPresentation, signVerifiablePresentation, ldpVpSignatureSuite) = authorizationMethods.first(where: { $0.type == .openId4VpPresentation })
+            case let .presentationDuringIssuance(jsonLdCanonicalizer, selectCredentialsForPresentation, signVerifiablePresentation) = authorizationMethods.first(where: { $0.type == .openId4VpPresentation })
         else {
             throw InteractiveAuthorizationException(message: "Presentation callback missing")
         }
         
         let authorizationService = PresentationDuringIssuanceAuthorizationMethodService(
+            jsonLdCanonicalizer: jsonLdCanonicalizer,
             selectCredentialsForPresentation: selectCredentialsForPresentation,
             signVerifiablePresentation: signVerifiablePresentation,
-            signatureSuite: ldpVpSignatureSuite,
             networkManager: self.networkManager
         )
         

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/Handler/InteractiveAuthorizationHandler.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/Handler/InteractiveAuthorizationHandler.swift
@@ -144,13 +144,14 @@ class InteractiveAuthorizationHandler {
         }
         
         guard
-            case let .presentationDuringIssuance(jsonLdCanonicalizer, selectCredentialsForPresentation, signVerifiablePresentation) = authorizationMethods.first(where: { $0.type == .openId4VpPresentation })
+            case let .presentationDuringIssuance(jsonLdCanonicalizer, openid4vpWalletConfig, selectCredentialsForPresentation, signVerifiablePresentation) = authorizationMethods.first(where: { $0.type == .openId4VpPresentation })
         else {
             throw InteractiveAuthorizationException(message: "Presentation callback missing")
         }
         
         let authorizationService = PresentationDuringIssuanceAuthorizationMethodService(
             jsonLdCanonicalizer: jsonLdCanonicalizer,
+            openid4vpWalletConfig: openid4vpWalletConfig,
             selectCredentialsForPresentation: selectCredentialsForPresentation,
             signVerifiablePresentation: signVerifiablePresentation,
             networkManager: self.networkManager

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/OpenID4VP/OpenID4VPInteraction.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/OpenID4VP/OpenID4VPInteraction.swift
@@ -3,8 +3,7 @@ import OpenID4VPBridge
 
 internal protocol OpenID4VPInteracting {
     func authenticateVerifier(
-        authRequest: [String: Any],
-        shouldValidateClient: Bool
+        authRequest: [String: Any]
     ) async throws -> AuthorizationRequest
     
     func constructUnsignedVPToken(
@@ -21,13 +20,12 @@ internal protocol OpenID4VPInteracting {
 class OpenID4VPInteraction: OpenID4VPInteracting {
     private let openId4vp: OpenID4VP
     
-    init(jsonLdCanonicalizer:JsonLdCanonicalizerCallback?, traceabilityId: String) {
-        openId4vp = OpenID4VP(traceabilityId: traceabilityId, jsonLdCanonicalizer: jsonLdCanonicalizer)
+    init(jsonLdCanonicalizer:JsonLdCanonicalizerCallback?, traceabilityId: String, openid4vpWalletConfig: WalletConfig) {
+        openId4vp = OpenID4VP(traceabilityId: traceabilityId, walletConfig: openid4vpWalletConfig, jsonLdCanonicalizer: jsonLdCanonicalizer)
     }
     
     func authenticateVerifier(
-        authRequest: [String: Any],
-        shouldValidateClient: Bool
+        authRequest: [String: Any]
     ) async throws -> AuthorizationRequest {
         try await openId4vp.authenticateVerifier(
             authorizationRequest: authRequest

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/OpenID4VP/OpenID4VPInteraction.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/OpenID4VP/OpenID4VPInteraction.swift
@@ -4,14 +4,11 @@ import OpenID4VPBridge
 internal protocol OpenID4VPInteracting {
     func authenticateVerifier(
         authRequest: [String: Any],
-        trustedVerifiers: [Verifier],
         shouldValidateClient: Bool
     ) async throws -> AuthorizationRequest
     
     func constructUnsignedVPToken(
-        verifiableCredentials: [String: [FormatType: [OpenID4VPAnyCodable]]],
-        holderId: String?,
-        ldpVpSignatureSuite: String?
+        selectedCredentials: [String: [Credential]]
     ) async throws -> [UnsignedVPToken]
     
     func constructVPResponse(
@@ -24,31 +21,24 @@ internal protocol OpenID4VPInteracting {
 class OpenID4VPInteraction: OpenID4VPInteracting {
     private let openId4vp: OpenID4VP
     
-    init(traceabilityId: String) {
-        openId4vp = OpenID4VP(traceabilityId: traceabilityId, walletMetadata: nil)
+    init(jsonLdCanonicalizer:JsonLdCanonicalizerCallback?, traceabilityId: String) {
+        openId4vp = OpenID4VP(traceabilityId: traceabilityId, jsonLdCanonicalizer: jsonLdCanonicalizer)
     }
     
     func authenticateVerifier(
         authRequest: [String: Any],
-        trustedVerifiers: [Verifier],
         shouldValidateClient: Bool
     ) async throws -> AuthorizationRequest {
         try await openId4vp.authenticateVerifier(
-            authorizationRequest: authRequest,
-            trustedVerifiers: trustedVerifiers,
-            shouldValidateClient: shouldValidateClient
+            authorizationRequest: authRequest
         )
     }
     
     func constructUnsignedVPToken(
-        verifiableCredentials: [String: [FormatType: [OpenID4VPAnyCodable]]],
-        holderId: String?,
-        ldpVpSignatureSuite: String?
+        selectedCredentials verifiableCredentials: [String: [Credential]]
     ) async throws -> [UnsignedVPToken] {
         try await openId4vp.constructUnsignedVPToken(
-            verifiableCredentials: verifiableCredentials,
-            holderId: holderId,
-            signatureSuite: ldpVpSignatureSuite
+            selectedCredentials: verifiableCredentials
         )
     }
     

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/OpenID4VP/OpenID4VPInteraction.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/OpenID4VP/OpenID4VPInteraction.swift
@@ -12,10 +12,10 @@ internal protocol OpenID4VPInteracting {
         verifiableCredentials: [String: [FormatType: [OpenID4VPAnyCodable]]],
         holderId: String?,
         ldpVpSignatureSuite: String?
-    ) async throws -> [UnsignedVPTokenV2]
+    ) async throws -> [UnsignedVPToken]
     
     func constructVPResponse(
-        vpTokenSigningResults: [VPTokenSigningResultV2]
+        vpTokenSigningResults: [VPTokenSigningResult]
     ) -> [String: Any]
     
     func constructErrorInfo(exception: Error) -> [String: Any]
@@ -44,7 +44,7 @@ class OpenID4VPInteraction: OpenID4VPInteracting {
         verifiableCredentials: [String: [FormatType: [OpenID4VPAnyCodable]]],
         holderId: String?,
         ldpVpSignatureSuite: String?
-    ) async throws -> [UnsignedVPTokenV2] {
+    ) async throws -> [UnsignedVPToken] {
         try await openId4vp.constructUnsignedVPToken(
             verifiableCredentials: verifiableCredentials,
             holderId: holderId,
@@ -53,7 +53,7 @@ class OpenID4VPInteraction: OpenID4VPInteracting {
     }
     
     func constructVPResponse(
-        vpTokenSigningResults: [VPTokenSigningResultV2]
+        vpTokenSigningResults: [VPTokenSigningResult]
     ) -> [String: Any] {
         openId4vp.constructVPResponse(vpTokenSigningResults: vpTokenSigningResults)
     }

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/OpenID4VP/OpenID4VPInteraction.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/OpenID4VP/OpenID4VPInteraction.swift
@@ -45,7 +45,7 @@ class OpenID4VPInteraction: OpenID4VPInteracting {
         holderId: String?,
         ldpVpSignatureSuite: String?
     ) async throws -> [UnsignedVPTokenV2] {
-        try await openId4vp.constructUnsignedVPTokenV2(
+        try await openId4vp.constructUnsignedVPToken(
             verifiableCredentials: verifiableCredentials,
             holderId: holderId,
             signatureSuite: ldpVpSignatureSuite
@@ -55,7 +55,7 @@ class OpenID4VPInteraction: OpenID4VPInteracting {
     func constructVPResponse(
         vpTokenSigningResults: [VPTokenSigningResultV2]
     ) -> [String: Any] {
-        openId4vp.constructVPResponseV2(vpTokenSigningResults: vpTokenSigningResults)
+        openId4vp.constructVPResponse(vpTokenSigningResults: vpTokenSigningResults)
     }
     
     func constructErrorInfo(exception: Error) -> [String: Any] {

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.swift
@@ -8,22 +8,20 @@ class PresentationDuringIssuanceAuthorizationMethodService: AuthorizationMethodS
     private let signVerifiablePresentation: SignVerifiablePresentationCallback
     private let openId4vp: OpenID4VPInteracting
     private let networkManager: NetworkManager
-    private let ldpVpSignatureSuite: String?
 
     init(
         jsonLdCanonicalizer: JsonLdCanonicalizerCallback?,
+        openid4vpWalletConfig: WalletConfig,
         selectCredentialsForPresentation: @escaping SelectCredentialsForPresentationCallback,
         signVerifiablePresentation: @escaping SignVerifiablePresentationCallback,
-        signatureSuite: String? = nil,
         networkManager: NetworkManager = NetworkManager.shared,
         openId4vp: OpenID4VPInteracting? = nil
     ) {
         self.jsonLdCanonicalizer = jsonLdCanonicalizer
         self.selectCredentialsForPresentation = selectCredentialsForPresentation
         self.signVerifiablePresentation = signVerifiablePresentation
-        self.openId4vp = openId4vp ?? OpenID4VPInteraction(jsonLdCanonicalizer: jsonLdCanonicalizer, traceabilityId: Util.getTraceabilityId())
+        self.openId4vp = openId4vp ?? OpenID4VPInteraction(jsonLdCanonicalizer: jsonLdCanonicalizer, traceabilityId: Util.getTraceabilityId(), openid4vpWalletConfig: openid4vpWalletConfig)
         self.networkManager = networkManager
-        ldpVpSignatureSuite = signatureSuite
     }
 
     func type() -> String {
@@ -77,7 +75,7 @@ class PresentationDuringIssuanceAuthorizationMethodService: AuthorizationMethodS
     }
 
     private func validatePresentationRequest(request: [String: Any]) async throws -> AuthorizationRequest {
-        return try await openId4vp.authenticateVerifier(authRequest: request, shouldValidateClient: false)
+        return try await openId4vp.authenticateVerifier(authRequest: request)
     }
 
     private func handlePresentation(vpRequest: AuthorizationRequest) async throws -> [String: Any] {

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.swift
@@ -3,6 +3,7 @@ import OpenID4VP
 import OpenID4VPBridge
 
 class PresentationDuringIssuanceAuthorizationMethodService: AuthorizationMethodService {
+    private let jsonLdCanonicalizer: JsonLdCanonicalizerCallback?
     private let selectCredentialsForPresentation: SelectCredentialsForPresentationCallback
     private let signVerifiablePresentation: SignVerifiablePresentationCallback
     private let openId4vp: OpenID4VPInteracting
@@ -10,15 +11,17 @@ class PresentationDuringIssuanceAuthorizationMethodService: AuthorizationMethodS
     private let ldpVpSignatureSuite: String?
 
     init(
+        jsonLdCanonicalizer: JsonLdCanonicalizerCallback?,
         selectCredentialsForPresentation: @escaping SelectCredentialsForPresentationCallback,
         signVerifiablePresentation: @escaping SignVerifiablePresentationCallback,
         signatureSuite: String? = nil,
         networkManager: NetworkManager = NetworkManager.shared,
         openId4vp: OpenID4VPInteracting? = nil
     ) {
+        self.jsonLdCanonicalizer = jsonLdCanonicalizer
         self.selectCredentialsForPresentation = selectCredentialsForPresentation
         self.signVerifiablePresentation = signVerifiablePresentation
-        self.openId4vp = openId4vp ?? OpenID4VPInteraction(traceabilityId: Util.getTraceabilityId())
+        self.openId4vp = openId4vp ?? OpenID4VPInteraction(jsonLdCanonicalizer: jsonLdCanonicalizer, traceabilityId: Util.getTraceabilityId())
         self.networkManager = networkManager
         ldpVpSignatureSuite = signatureSuite
     }
@@ -74,31 +77,17 @@ class PresentationDuringIssuanceAuthorizationMethodService: AuthorizationMethodS
     }
 
     private func validatePresentationRequest(request: [String: Any]) async throws -> AuthorizationRequest {
-        return try await openId4vp.authenticateVerifier(authRequest: request, trustedVerifiers: [Verifier](), shouldValidateClient: false)
+        return try await openId4vp.authenticateVerifier(authRequest: request, shouldValidateClient: false)
     }
 
     private func handlePresentation(vpRequest: AuthorizationRequest) async throws -> [String: Any] {
-        let selectedCredentials: [String: [FormatType: [OpenID4VPAnyCodable]]] = try await selectCredentialsForPresentation(vpRequest)
+        let selectedCredentials: [String: [Credential]] = try await selectCredentialsForPresentation(vpRequest)
         if selectedCredentials.isEmpty {
             throw AccessDenied(message: "No credentials selected by user", className: "PresentationDuringIssuanceAuthorizationMethodService")
         }
 
-        let holderId: String? = extractHolderId(credentials: selectedCredentials)
-
-        let flattenedFormatEntries: [(FormatType, [OpenID4VPAnyCodable])] = selectedCredentials.values.flatMap { formatMap in
-            formatMap.map { ($0.key, $0.value) }
-        }
-        let hasLdpVc = flattenedFormatEntries.filter { formatType, _ in
-            formatType == .ldp_vc
-        }.count != 0
-        if hasLdpVc && ldpVpSignatureSuite == nil {
-            throw InteractiveAuthorizationException(message: "Missing signature suite for LDP VC")
-        }
-
         let unsignedVpTokens: [UnsignedVPToken] = try await openId4vp.constructUnsignedVPToken(
-            verifiableCredentials: selectedCredentials,
-            holderId: holderId,
-            ldpVpSignatureSuite: ldpVpSignatureSuite
+            selectedCredentials: selectedCredentials
         )
         let signedVpTokens: [VPTokenSigningResult] = try await signVerifiablePresentation(unsignedVpTokens)
 

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.swift
@@ -95,12 +95,12 @@ class PresentationDuringIssuanceAuthorizationMethodService: AuthorizationMethodS
             throw InteractiveAuthorizationException(message: "Missing signature suite for LDP VC")
         }
 
-        let unsignedVpTokens: [UnsignedVPTokenV2] = try await openId4vp.constructUnsignedVPToken(
+        let unsignedVpTokens: [UnsignedVPToken] = try await openId4vp.constructUnsignedVPToken(
             verifiableCredentials: selectedCredentials,
             holderId: holderId,
             ldpVpSignatureSuite: ldpVpSignatureSuite
         )
-        let signedVpTokens: [VPTokenSigningResultV2] = try await signVerifiablePresentation(unsignedVpTokens)
+        let signedVpTokens: [VPTokenSigningResult] = try await signVerifiablePresentation(unsignedVpTokens)
 
         return openId4vp.constructVPResponse(vpTokenSigningResults: signedVpTokens)
     }

--- a/Sources/VCIClient/constants/CallbackTypes.swift
+++ b/Sources/VCIClient/constants/CallbackTypes.swift
@@ -19,7 +19,7 @@ public typealias TxCodeCallback = ((_ inputMode: String?, _ description: String?
 // Presentation During Issuance related Callbacks
 
 public typealias SelectCredentialsForPresentationCallback = (_ ovpRequest: AuthorizationRequest) async throws -> [String : [FormatType : [OpenID4VPAnyCodable]]]
-public typealias SignVerifiablePresentationCallback = (_ payload: [UnsignedVPTokenV2]) async throws -> [VPTokenSigningResultV2]
+public typealias SignVerifiablePresentationCallback = (_ payload: [UnsignedVPToken]) async throws -> [VPTokenSigningResult]
 
 
 // Redirect To Web related Callbacks

--- a/Sources/VCIClient/constants/CallbackTypes.swift
+++ b/Sources/VCIClient/constants/CallbackTypes.swift
@@ -18,7 +18,7 @@ public typealias TxCodeCallback = ((_ inputMode: String?, _ description: String?
 
 // Presentation During Issuance related Callbacks
 
-public typealias SelectCredentialsForPresentationCallback = (_ ovpRequest: AuthorizationRequest) async throws -> [String : [FormatType : [OpenID4VPAnyCodable]]]
+public typealias SelectCredentialsForPresentationCallback = (_ ovpRequest: AuthorizationRequest) async throws -> [String : [Credential]]
 public typealias SignVerifiablePresentationCallback = (_ payload: [UnsignedVPToken]) async throws -> [VPTokenSigningResult]
 
 

--- a/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/Handler/InteractiveAuthorizationHandlerTests.swift
+++ b/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/Handler/InteractiveAuthorizationHandlerTests.swift
@@ -25,7 +25,9 @@ final class InteractiveAuthorizationHandlerTests: XCTestCase {
     ) -> [AuthorizationMethod] {
         [
             .presentationDuringIssuance(
-                selectCredentialsForPresentation: select,
+                jsonLdCanonicalizer: { data in
+                    return "Y2Fub25pY2FsaXplZA=="
+                }, selectCredentialsForPresentation: select,
                 signVerifiablePresentation: sign
             )
         ]
@@ -53,9 +55,11 @@ final class InteractiveAuthorizationHandlerTests: XCTestCase {
         let select: SelectCredentialsForPresentationCallback = { _ in
             return [
                 "cred1": [
-                    .ldp_vc: [
-                        OpenID4VPAnyCodable("dummy-cred")
-                    ]
+                    OpenID4VPCredential(
+                        format: .ldp_vc,
+                        data: OpenID4VPAnyCodable("dummy-cred"),
+                        credentialId: "cred1"
+                    )
                 ]
             ]
         }

--- a/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodServiceTests.swift
+++ b/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodServiceTests.swift
@@ -6,8 +6,6 @@ import OpenID4VP
 private final class DummyAuthorizationRequestData: AuthorizationRequestData {}
 
 private final class FakeOpenID4VP: OpenID4VPInteracting {
-    
-
     enum Behavior {
         case success
         case authThrows(OpenID4VPException)
@@ -17,11 +15,10 @@ private final class FakeOpenID4VP: OpenID4VPInteracting {
 
     var behavior: Behavior = .success
 
-    private let real = OpenID4VP(traceabilityId: "", walletMetadata: nil)
+    private let real = OpenID4VP(traceabilityId: "", walletConfig: WalletConfig())
 
     func authenticateVerifier(
         authRequest authorizationRequest: [String : Any],
-        trustedVerifiers: [Verifier],
         shouldValidateClient: Bool
     ) async throws -> AuthorizationRequest {
 
@@ -31,17 +28,14 @@ private final class FakeOpenID4VP: OpenID4VPInteracting {
         default:
             return try await real.authenticateVerifier(
                 authorizationRequest: authorizationRequest,
-                trustedVerifiers: trustedVerifiers,
                 shouldValidateClient: shouldValidateClient
             )
         }
     }
 
     func constructUnsignedVPToken(
-        verifiableCredentials: [String : [FormatType : [OpenID4VPAnyCodable]]],
-        holderId: String?,
-        ldpVpSignatureSuite: String?
-    ) async throws -> [UnsignedVPTokenV2] {
+        selectedCredentials verifiableCredentials: [String : [Credential]],
+    ) async throws -> [UnsignedVPToken] {
 
         switch behavior {
         case .unsignedThrows(let err):
@@ -52,7 +46,7 @@ private final class FakeOpenID4VP: OpenID4VPInteracting {
     }
 
     func constructVPResponse(
-        vpTokenSigningResults: [VPTokenSigningResultV2]
+        vpTokenSigningResults: [VPTokenSigningResult]
     ) -> [String : Any] {
 
         switch behavior {
@@ -124,11 +118,11 @@ final class PresentationDuringIssuanceAuthorizationMethodServiceTests: XCTestCas
         let selectCallback = select ?? { _ in
             return [
                 "cred1": [
-                    FormatType.ldp_vc: [
-                        OpenID4VPAnyCodable([
-                            "credentialSubject": ["id": "did:example:123="]
-                        ])
-                    ]
+                    Credential(
+                        format: .ldp_vc,
+                        data: OpenID4VPAnyCodable(["credentialSubject": ["id": "did:example:123="]]),
+                        credentialId: "cred1"
+                    )
                 ]
             ]
         }
@@ -138,6 +132,9 @@ final class PresentationDuringIssuanceAuthorizationMethodServiceTests: XCTestCas
         }
 
         return PresentationDuringIssuanceAuthorizationMethodService(
+            jsonLdCanonicalizer: { jsonLd in
+                return "Y2Fub25pY2FsaXplZA=="
+            },
             selectCredentialsForPresentation: selectCallback,
             signVerifiablePresentation: signCallback,
             signatureSuite: signatureSuite,

--- a/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodServiceTests.swift
+++ b/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodServiceTests.swift
@@ -18,8 +18,7 @@ private final class FakeOpenID4VP: OpenID4VPInteracting {
     private let real = OpenID4VP(traceabilityId: "", walletConfig: WalletConfig())
 
     func authenticateVerifier(
-        authRequest authorizationRequest: [String : Any],
-        shouldValidateClient: Bool
+        authRequest authorizationRequest: [String : Any]
     ) async throws -> AuthorizationRequest {
 
         switch behavior {
@@ -109,7 +108,6 @@ final class PresentationDuringIssuanceAuthorizationMethodServiceTests: XCTestCas
     private func makeService(
         openId4vp: OpenID4VPInteracting,
         network: MockNetworkManager = MockNetworkManager(),
-        signatureSuite: String? = "Ed25519Signature2018",
         select: SelectCredentialsForPresentationCallback? = nil,
         sign: SignVerifiablePresentationCallback? = nil
     ) -> PresentationDuringIssuanceAuthorizationMethodService {
@@ -134,9 +132,9 @@ final class PresentationDuringIssuanceAuthorizationMethodServiceTests: XCTestCas
             jsonLdCanonicalizer: { jsonLd in
                 return "Y2Fub25pY2FsaXplZA=="
             },
+            openid4vpWalletConfig: WalletConfig(),
             selectCredentialsForPresentation: selectCallback,
             signVerifiablePresentation: signCallback,
-            signatureSuite: signatureSuite,
             networkManager: network,
             openId4vp: openId4vp
         )

--- a/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodServiceTests.swift
+++ b/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodServiceTests.swift
@@ -27,14 +27,13 @@ private final class FakeOpenID4VP: OpenID4VPInteracting {
             throw ex
         default:
             return try await real.authenticateVerifier(
-                authorizationRequest: authorizationRequest,
-                shouldValidateClient: shouldValidateClient
+                authorizationRequest: authorizationRequest
             )
         }
     }
 
     func constructUnsignedVPToken(
-        selectedCredentials verifiableCredentials: [String : [Credential]],
+        selectedCredentials verifiableCredentials: [String : [Credential]]
     ) async throws -> [UnsignedVPToken] {
 
         switch behavior {

--- a/Tests/VCIClientTests/mocks/MockDataExtensions.swift
+++ b/Tests/VCIClientTests/mocks/MockDataExtensions.swift
@@ -82,4 +82,3 @@ extension TokenResponse {
     }
 }
 
-struct DummyVPTokenSigningResult: VPTokenSigningResult {}


### PR DESCRIPTION
#### Public API Changes

The `AuthorizationMethod` for `presentationDuringIssuance` has been updated to align with the changes in OVP library version 0.8.0. The following are the key changes in the public API:

##### 1. Removal of ldpVpSignatureSuite

- `ldpVpSignatureSuite` has been removed as part of the upgrade to OVP library version 0.8.0. This means that the `presentationDuringIssuance` authorization method will no longer support the Linked Data Proof (LDP) signature suite for verifiable presentations.
- This change is happening since OVP library version 0.8.0 has removed support for LDP signature suite input and uses `JsonWebSignatureSuite2020` as the default signature suite for verifiable presentations. Therefore, the `presentationDuringIssuance` authorization method will now only support the `JsonWebSignatureSuite2020` signature suite for `ldp_vp` verifiable presentations.

##### 2. SelectCredentialsForPresentationCallback callback Type
SelectCredentialsForPresentationCallback's type has now changed as per OVP library's changes. The following table summarizes the changes in the public API:

|        | 0.7.0                                    | New                         | Notes                                                                                                                                                                                                                                         |
|--------|------------------------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| Output | Map\<String, Map<FormatType, AnyCodable>> | Map\<String, Array<Credential>> | Previously, the selected credentials was required to be a map of input descriptor ID to selected credentials grouped by format. <br/> It now changes to map of input descriptor ID / credential Query ID to its list of selected `Credential` |

##### 3. SignVerifiablePresentationCallback callback Type
SignVerifiablePresentationCallback's type has now changed as per OVP library's changes. The following table summarizes the changes in the public API:

|        | 0.7.0                         | New                        | Notes                                                    |
|--------|-------------------------------|-------------------------------|----------------------------------------------------------|
| Input  | Array\<UnsignedVPTokenV2>      | Array\<UnsignedVPToken>        | This change is only name level and no structural changes |
| Output | Array\<VPTokenSigningResultV2> | Array\<VPTokenSigningResultV2> | This change is only name level and no structural changes |


##### 4. Optional Input param for canonicalization of JSON-LD data. (Swift only)

- Optional Input param `jsonLdCanonicalizer` callback for canonicalization of JSON-LD data.
   - Applicable for presenting credentials of format `ldp_vc`
   - Required when ldp_vc presentation are required

Fixes: https://github.com/inji/inji-wallet/issues/2473

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved OpenID4VP presentation flow: simplified credential selection and VP token handling, plus optional JSON-LD canonicalization support during presentation.

* **Chores**
  * Updated dependency pins and added cryptography and multiformat libraries to the lockfile.

* **Tests**
  * Updated tests and mocks to align with the new presentation flow and token types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->