### PR TITLE
fix(Pdi):delegate PDI request validation to OpenID4VP

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -42,7 +42,7 @@
       "location" : "https://github.com/inji/inji-openid4vp-ios-swift",
       "state" : {
         "branch" : "develop",
-        "revision" : "921fcc6e95e3cc4ffcd59936e2486950049e4fc4"
+        "revision" : "2dbcd19d401ebaa96fb2b4c788b19f548485e733"
       }
     },
     {

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.swift
@@ -75,7 +75,12 @@ class PresentationDuringIssuanceAuthorizationMethodService: AuthorizationMethodS
     }
 
     private func validatePresentationRequest(request: [String: Any]) async throws -> AuthorizationRequest {
-        return try await openId4vp.authenticateVerifier(authRequest: request)
+        let authorizationRequest = try await openId4vp.authenticateVerifier(authRequest: request)
+        guard authorizationRequest.responseMode == "iar-post"
+                || authorizationRequest.responseMode == "iar-post.jwt" else {
+            throw IllegalArgumentException("response_mode must be 'iar-post' or 'iar-post.jwt'")
+        }
+        return authorizationRequest
     }
 
     private func handlePresentation(vpRequest: AuthorizationRequest) async throws -> [String: Any] {

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationInteractionResponse.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationInteractionResponse.swift
@@ -88,59 +88,6 @@ final class PresentationInteractionResponse: InteractionResponse, Decodable {
         guard !openid4vpRequest.isEmpty else {
             throw IllegalArgumentException("openid4vpRequest must not be empty")
         }
-
-        if openid4vpRequest.keys.contains("request") {
-            try validateSignedRequest()
-        } else {
-            try validateUnsignedRequest()
-        }
-    }
-
-    private func validateUnsignedRequest() throws {
-        guard let responseType = openid4vpRequest["response_type"] as? String else {
-            throw ValidationError.missing("response_type")
-        }
-        guard responseType == "vp_token" else {
-            throw ValidationError.invalid("response_type")
-        }
-
-        try validateResponseMode(openid4vpRequest)
-    }
-
-    private func validateSignedRequest() throws {
-        guard let jwt = openid4vpRequest["request"] as? String else {
-            throw IllegalArgumentException("Missing or invalid 'request' JWT")
-        }
-
-        let decodedVPRequest = try decodeJwtPayload(jwt: jwt)
-
-        try validateResponseMode(decodedVPRequest)
-    }
-    
-    private func validateResponseMode(_ vpRequest: [String: Any]) throws {
-        guard let responseMode = vpRequest["response_mode"] as? String else {
-            throw IllegalArgumentException("Missing or invalid 'response_mode'")
-        }
-        guard responseMode == "iar-post" || responseMode == "iar-post.jwt" else {
-            throw IllegalArgumentException("response_mode must be 'iar-post' or 'iar-post.jwt'")
-        }
-    }
-
-    func decodeJwtPayload(jwt: String) throws -> [String: Any] {
-        let parts = jwt.split(separator: ".")
-        guard parts.count == 3 else { throw ValidationError.malformedJwt }
-
-        guard let data = try? Data(base64URLEncodedString: String(parts[1])) else {
-            throw ValidationError.malformedJwt
-        }
-
-        let json = try JSONSerialization.jsonObject(with: data, options: [])
-
-        guard let dict = json as? [String: Any] else {
-            throw ValidationError.invalid("jwt payload")
-        }
-
-        return dict
     }
 }
 
@@ -154,5 +101,4 @@ enum ValidationError: Error {
     case missing(String)
     case invalid(String)
     case blank(String)
-    case malformedJwt
 }

--- a/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodServiceTests.swift
+++ b/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodServiceTests.swift
@@ -14,6 +14,7 @@ private final class FakeOpenID4VP: OpenID4VPInteracting {
     }
 
     var behavior: Behavior = .success
+    var constructedError: Error?
 
     private let real = OpenID4VP(traceabilityId: "", walletConfig: WalletConfig())
 
@@ -59,6 +60,7 @@ private final class FakeOpenID4VP: OpenID4VPInteracting {
     }
 
     func constructErrorInfo(exception: Error) -> [String : Any] {
+        constructedError = exception
         return [
             "error": "server_error",
             "error_description": "constructed error: \(exception)"
@@ -82,12 +84,23 @@ final class PresentationDuringIssuanceAuthorizationMethodServiceTests: XCTestCas
                         "ldp_vc": [
                             "proof_type": ["Ed25519Signature2018"]
                         ]
+                    ],
+                    "constraints": [
+                        "fields": [
+                            [
+                                "path": ["$.credentialSubject.id"],
+                                "filter": [
+                                    "type": "string",
+                                    "pattern": "did:example:"
+                                ]
+                            ]
+                        ]
                     ]
                 ]
             ]
         ],
         "response_type": "vp_token",
-        "response_mode": "direct_post",
+        "response_mode": "iar-post",
         "nonce": "abc",
         "state": "xyz"
     ]
@@ -95,11 +108,12 @@ final class PresentationDuringIssuanceAuthorizationMethodServiceTests: XCTestCas
 
     private func makeRequestData(
         authSession: String = "auth-session-1",
-        iar: String = "https://issuer.example.com/iar"
+        iar: String = "https://issuer.example.com/iar",
+        ovpRequest: [String: Any]? = nil
     ) -> PresentationDuringIssuanceRequestData {
 
         PresentationDuringIssuanceRequestData(
-            ovpRequest: authorizationRequest,
+            ovpRequest: ovpRequest ?? authorizationRequest,
             authSession: authSession,
             iar: iar
         )
@@ -227,6 +241,42 @@ final class PresentationDuringIssuanceAuthorizationMethodServiceTests: XCTestCas
         )
 
         XCTAssertEqual(response.error, "access_denied")
+    }
+
+    func test_unsupported_response_mode_posts_error_without_selecting_credentials() async throws {
+        let fake = FakeOpenID4VP()
+        let network = MockNetworkManager()
+        let issuerResponse = AuthorizationResponse(
+            authorizationCode: nil,
+            status: "error",
+            error: "invalid_request",
+            errorDescription: "unsupported response mode",
+            authSession: "auth-session-1"
+        )
+        network.responseBody =
+            String(data: try JSONEncoder().encode(issuerResponse), encoding: .utf8)!
+
+        var didSelectCredentials = false
+        let sut = makeService(
+            openId4vp: fake,
+            network: network,
+            select: { _ in
+                didSelectCredentials = true
+                return [:]
+            }
+        )
+        var unsupportedRequest = authorizationRequest
+        unsupportedRequest["response_mode"] = "direct_post"
+
+        _ = try await sut.authorizeUser(
+            requestData: makeRequestData(ovpRequest: unsupportedRequest)
+        )
+
+        XCTAssertFalse(didSelectCredentials)
+        XCTAssertEqual(
+            fake.constructedError?.localizedDescription,
+            "response_mode must be 'iar-post' or 'iar-post.jwt'"
+        )
     }
 
     // MARK: - Network failure

--- a/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationInteractionResponseTests.swift
+++ b/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationInteractionResponseTests.swift
@@ -46,15 +46,14 @@ final class PresentationInteractionResponseTests: XCTestCase {
         )
     }
 
-    func testValidate_acceptsUnsignedRequestWithSupportedResponseMode() throws {
+    func testValidate_acceptsUnsignedRequestForLibraryValidation() throws {
         let response = try PresentationInteractionResponse(
             json: [
                 "status": "require_interaction",
                 "type": "openid4vp_presentation",
                 "auth_session": "session-1",
                 "openid4vp_request": [
-                    "response_type": "vp_token",
-                    "response_mode": "iar-post.jwt",
+                    "response_type": "vp_token"
                 ],
             ]
         )
@@ -62,18 +61,29 @@ final class PresentationInteractionResponseTests: XCTestCase {
         XCTAssertNoThrow(try response.validate())
     }
 
-    func testValidate_acceptsSignedRequestWithSupportedResponseMode() throws {
-        let payload = #"{"response_mode":"iar-post"}"#
-        let encodedPayload = Data(payload.utf8).base64URLEncodedString()
-        let jwt = "header.\(encodedPayload).signature"
-
+    func testValidate_acceptsSignedRequestForLibraryValidation() throws {
         let response = try PresentationInteractionResponse(
             json: [
                 "status": "require_interaction",
                 "type": "openid4vp_presentation",
                 "auth_session": "session-1",
                 "openid4vp_request": [
-                    "request": jwt,
+                    "request": "signed-request-jwt",
+                ],
+            ]
+        )
+
+        XCTAssertNoThrow(try response.validate())
+    }
+
+    func testValidate_acceptsRequestUriForLibraryValidation() throws {
+        let response = try PresentationInteractionResponse(
+            json: [
+                "status": "require_interaction",
+                "type": "openid4vp_presentation",
+                "auth_session": "session-1",
+                "openid4vp_request": [
+                    "request_uri": "https://verifier.example.com/request/123",
                 ],
             ]
         )
@@ -99,91 +109,7 @@ final class PresentationInteractionResponseTests: XCTestCase {
         }
     }
 
-    func testValidate_rejectsMissingResponseTypeInUnsignedRequest() throws {
-        let response = try PresentationInteractionResponse(
-            json: [
-                "status": "require_interaction",
-                "type": "openid4vp_presentation",
-                "auth_session": "session-1",
-                "openid4vp_request": [
-                    "response_mode": "iar-post",
-                ],
-            ]
-        )
-
-        XCTAssertThrowsError(try response.validate())
-    }
-
-    func testValidate_rejectsInvalidResponseTypeInUnsignedRequest() throws {
-        let response = try PresentationInteractionResponse(
-            json: [
-                "status": "require_interaction",
-                "type": "openid4vp_presentation",
-                "auth_session": "session-1",
-                "openid4vp_request": [
-                    "response_type": "code",
-                    "response_mode": "iar-post",
-                ],
-            ]
-        )
-
-        XCTAssertThrowsError(try response.validate())
-    }
-
-    func testValidate_rejectsMissingResponseMode() throws {
-        let response = try PresentationInteractionResponse(
-            json: [
-                "status": "require_interaction",
-                "type": "openid4vp_presentation",
-                "auth_session": "session-1",
-                "openid4vp_request": [
-                    "response_type": "vp_token",
-                ],
-            ]
-        )
-
-        XCTAssertThrowsError(try response.validate()) { error in
-            XCTAssertTrue(error is IllegalArgumentException)
-        }
-    }
-
-    func testValidate_rejectsUnsupportedResponseMode() throws {
-        let response = try PresentationInteractionResponse(
-            json: [
-                "status": "require_interaction",
-                "type": "openid4vp_presentation",
-                "auth_session": "session-1",
-                "openid4vp_request": [
-                    "response_type": "vp_token",
-                    "response_mode": "direct_post",
-                ],
-            ]
-        )
-
-        XCTAssertThrowsError(try response.validate()) { error in
-            XCTAssertTrue(error is IllegalArgumentException)
-        }
-    }
-
-    func testValidate_rejectsMalformedSignedRequestJwt() throws {
-        let response = try PresentationInteractionResponse(
-            json: [
-                "status": "require_interaction",
-                "type": "openid4vp_presentation",
-                "auth_session": "session-1",
-                "openid4vp_request": [
-                    "request": "not-a-jwt",
-                ],
-            ]
-        )
-
-        XCTAssertThrowsError(try response.validate())
-    }
-
-    func testDecodeJwtPayload_rejectsNonDictionaryPayload() throws {
-        let payload = #"["not","a","dictionary"]"#
-        let encodedPayload = Data(payload.utf8).base64URLEncodedString()
-        let jwt = "header.\(encodedPayload).signature"
+    func testValidate_rejectsEmptyRequest() throws {
         let response = try PresentationInteractionResponse(
             json: [
                 "status": "require_interaction",
@@ -193,6 +119,6 @@ final class PresentationInteractionResponseTests: XCTestCase {
             ]
         )
 
-        XCTAssertThrowsError(try response.decodeJwtPayload(jwt: jwt))
+        XCTAssertThrowsError(try response.validate())
     }
 }


### PR DESCRIPTION
## Summary
- delegate signed, unsigned, and by-reference OpenID4VP request validation to the OpenID4VP library
- enforce PDI response modes after OpenID4VP returns the normalized authorization request
- update interaction and authorization service tests, including unsupported response mode coverage

