### PR TITLE
refactor(ios): merge source error code into code 

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,43 +372,38 @@ They carry structured fields that help consumers identify whether the failure ca
 
 ### `VCIClientException` fields
 
-| Field                    | Type      | Meaning |
-|--------------------------|-----------|---------|
-| `code`                   | `String`  | The library-defined error code for the exception being thrown to the consumer. |
-| `message`                | `String`  | Human-readable summary of the failure, ready for logging or diagnostics. |
-| `sourceErrorCode`        | `String?` | The root `VCI-*` code from the underlying cause when the library wraps another `VCIClientException`. |
-| `serverErrorCode`        | `String?` | The issuer or authorization server `error` value when the remote service returned a structured OAuth/OID4VCI-style error response. |
-| `serverErrorDescription` | `String?` | The upstream `error_description` value when available. If the response body is not parseable JSON, the raw response body may be propagated here for diagnostics. |
+| Field                     | Type      | Meaning |
+|---------------------------|-----------|---------|
+| `code`                    | `String`  | The library-defined `VCI-*` error code. When the exception wraps another `VCIClientException`, `code` carries the **root** code resolved from the cause chain; otherwise it is the exception's own code. |
+| `message`                 | `String`  | Human-readable summary of the failure, ready for logging or diagnostics. |
+| `issuerErrorCode`         | `String?` | The issuer or authorization server `error` value when the remote service returned a structured OAuth/OID4VCI-style error response. |
+| `issuerErrorDescription`  | `String?` | The upstream `error_description` value when available. If the response body is not parseable JSON, the raw response body may be propagated here for diagnostics. |
 
 ### Error model
 
 The error model provides full observability into failures:
 
-- `code` identifies the current exception returned to the caller.
-- `sourceErrorCode` preserves the deeper `VCI-*` code when the current exception wraps another library exception.
-- `serverErrorCode` captures the upstream server `error` field when present.
-- `serverErrorDescription` captures the upstream `error_description`, or the raw error body when structured parsing is not possible.
+- `code` identifies the root library failure. When an exception wraps another library exception, `code` resolves to the deepest `VCI-*` code in the cause chain rather than the wrapper's own code.
+- `issuerErrorCode` captures the upstream server `error` field when present.
+- `issuerErrorDescription` captures the upstream `error_description`, or the raw error body when structured parsing is not possible.
 
 This means consumers can distinguish between:
 
-- a library wrapper error exposed at the public API boundary,
-- the original underlying library failure,
+- the original underlying library failure (surfaced through `code` even across wrapping),
 - and a server-originated error payload returned by the issuer or authorization server.
 
 #### Consumer guidance
 
-- Use `code` for primary client-side branching, telemetry dimensions, and product analytics.
-- Use `sourceErrorCode` when `code` represents a wrapper exception and you need the more specific underlying failure category.
-- Use `serverErrorCode` to decide whether a failure is recoverable through user action, such as re-authentication, retry, or correcting a request.
-- Use `serverErrorDescription` for logs, support tooling, and developer diagnostics. Avoid showing it directly to end users without sanitization because it may contain server-specific text.
+- Use `code` for primary client-side branching, telemetry dimensions, and product analytics. It identifies the root library failure even when the exception is wrapped.
+- Use `issuerErrorCode` to decide whether a failure is recoverable through user action, such as re-authentication, retry, or correcting a request.
+- Use `issuerErrorDescription` for logs, support tooling, and developer diagnostics. Avoid showing it directly to end users without sanitization because it may contain server-specific text.
 
 Some public API methods may wrap an internal `VCIClientException` into another `VCIClientException` before rethrowing it. This improves consistency at the API boundary without losing the root cause.
 
 Example:
 
-- `getIssuerMetadata()` may throw `VCI-010` at the API boundary.
-- `sourceErrorCode` may still contain `VCI-009` if the underlying failure was an issuer metadata fetch error.
-- `serverErrorCode` may contain a remote value such as `invalid_token` if the upstream endpoint returned it.
+- `getIssuerMetadata()` may wrap the failure at the API boundary, but `code` still resolves to `VCI-009` when the underlying failure was an issuer metadata fetch error.
+- `issuerErrorCode` may contain a remote value such as `invalid_token` if the upstream endpoint returned it.
 
 ### Recommended consumer handling
 
@@ -424,8 +419,8 @@ do {
     )
 } catch let error as VCIClientException {
     logger.error(
-        "VCI request failed. code=\(error.code), source=\(error.sourceErrorCode ?? "nil"), " +
-        "serverCode=\(error.serverErrorCode ?? "nil"), serverDescription=\(error.serverErrorDescription ?? "nil"), " +
+        "VCI request failed. code=\(error.code), " +
+        "issuerCode=\(error.issuerErrorCode ?? "nil"), issuerDescription=\(error.issuerErrorDescription ?? "nil"), " +
         "message=\(error.message)"
     )
 

--- a/Sources/VCIClient/authorizationCodeFlow/AuthorizationCodeFlowService.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/AuthorizationCodeFlowService.swift
@@ -144,8 +144,8 @@ class AuthorizationCodeFlowService {
             } catch let e as VCIClientException {
                 throw DownloadFailedException(
                     message: "Failed to resolve authorization server metadata for issuer \(e.localizedDescription)",
-                    serverErrorCode: e.serverErrorCode,
-                    serverErrorDescription: e.serverErrorDescription
+                    issuerErrorCode: e.issuerErrorCode,
+                    issuerErrorDescription: e.issuerErrorDescription
                 )
             }
 
@@ -165,8 +165,8 @@ class AuthorizationCodeFlowService {
             } catch let e as VCIClientException {
                 throw DownloadFailedException(
                     message: "Failed to obtain access token via authorization code flow: \(e.localizedDescription)",
-                    serverErrorCode: e.serverErrorCode,
-                    serverErrorDescription: e.serverErrorDescription,
+                    issuerErrorCode: e.issuerErrorCode,
+                    issuerErrorDescription: e.issuerErrorDescription,
                     cause: e
                 )
             } catch {
@@ -183,8 +183,8 @@ class AuthorizationCodeFlowService {
         } catch let e as VCIClientException {
             throw DownloadFailedException(
                 message: e.message,
-                serverErrorCode: e.serverErrorCode,
-                serverErrorDescription: e.serverErrorDescription,
+                issuerErrorCode: e.issuerErrorCode,
+                issuerErrorDescription: e.issuerErrorDescription,
                 cause: e
             )
         } catch {
@@ -241,7 +241,7 @@ class AuthorizationCodeFlowService {
                     authorizationMethods: authorizationMethods
                 )
             } catch let error as VCIClientException {
-                if error.serverErrorCode == Constants.MISSING_INTERACTION_TYPE_ERROR {
+                if error.issuerErrorCode == Constants.MISSING_INTERACTION_TYPE_ERROR {
                     return try await obtainAuthorizationCodeViaAuthorizationEndpoint(authorizationServerMetadata: authorizationServerMetadata, issuerMetadata: issuerMetadata, clientMetadata: clientMetadata, pkceSession: pkceSession, authorizationMethods: authorizationMethods)
                 } else {
                     throw error
@@ -279,8 +279,8 @@ class AuthorizationCodeFlowService {
         } catch let error as VCIClientException {
             throw DownloadFailedException(
                 message: "Interactive authorization failed at endpoint \(endpoint): \(error.localizedDescription)",
-                serverErrorCode: error.serverErrorCode,
-                serverErrorDescription: error.serverErrorDescription,
+                issuerErrorCode: error.issuerErrorCode,
+                issuerErrorDescription: error.issuerErrorDescription,
                 cause: error
             )
         } catch {

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/Handler/InteractiveAuthorizationHandler.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/Handler/InteractiveAuthorizationHandler.swift
@@ -63,8 +63,8 @@ class InteractiveAuthorizationHandler {
             Util.logError(message: "Interactive authorization failed: \(e.message)", className: "InteractiveAuthorizationHandler")
             throw InteractiveAuthorizationException(
                 message: "Interactive authorization failed: \(e.message)",
-                serverErrorCode: e.serverErrorCode,
-                serverErrorDescription: e.serverErrorDescription,
+                issuerErrorCode: e.issuerErrorCode,
+                issuerErrorDescription: e.issuerErrorDescription,
                 cause: e
             )
 
@@ -117,8 +117,8 @@ class InteractiveAuthorizationHandler {
             
             throw InteractiveAuthorizationException(
                 message: message,
-                serverErrorCode: error,
-                serverErrorDescription: errorDescription
+                issuerErrorCode: error,
+                issuerErrorDescription: errorDescription
             )
         }
         

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.swift
@@ -61,8 +61,8 @@ class PresentationDuringIssuanceAuthorizationMethodService: AuthorizationMethodS
         } catch let ex as VCIClientException {
             throw InteractiveAuthorizationException(
                 message: "Error during presentation authorization: \(ex.message)",
-                serverErrorCode: ex.serverErrorCode,
-                serverErrorDescription: ex.serverErrorDescription,
+                issuerErrorCode: ex.issuerErrorCode,
+                issuerErrorDescription: ex.issuerErrorDescription,
                 cause: ex
             )
 
@@ -139,8 +139,8 @@ class PresentationDuringIssuanceAuthorizationMethodService: AuthorizationMethodS
         } catch let ex as VCIClientException {
             throw InteractiveAuthorizationException(
                 message: "Error while posting VP response: \(ex.message)",
-                serverErrorCode: ex.serverErrorCode,
-                serverErrorDescription: ex.serverErrorDescription,
+                issuerErrorCode: ex.issuerErrorCode,
+                issuerErrorDescription: ex.issuerErrorDescription,
                 cause: ex
             )
 

--- a/Sources/VCIClient/common/Util.swift
+++ b/Sources/VCIClient/common/Util.swift
@@ -52,13 +52,13 @@ func mapToVciClientException(_ error: Error) -> VCIClientException {
         return VCIClientException(
             code: "VCI-010",
             message: vciError.message,
-            serverErrorCode: vciError.serverErrorCode, serverErrorDescription: vciError.serverErrorDescription, cause: vciError.cause ?? vciError
+            issuerErrorCode: vciError.issuerErrorCode, issuerErrorDescription: vciError.issuerErrorDescription, cause: vciError.cause ?? vciError
         )
     }
 
     return VCIClientException(
         code: "VCI-010",
         message: "Unknown Exception - \(error.localizedDescription)",
-        serverErrorCode: nil, serverErrorDescription: nil, cause: error
+        issuerErrorCode: nil, issuerErrorDescription: nil, cause: error
     )
 }

--- a/Sources/VCIClient/credential/request/CredentialRequestExecutor.swift
+++ b/Sources/VCIClient/credential/request/CredentialRequestExecutor.swift
@@ -93,8 +93,8 @@ class CredentialRequestExecutor {
 
             throw DownloadFailedException(
                 message: e.message,
-                serverErrorCode: e.serverErrorCode,
-                serverErrorDescription: e.serverErrorDescription,
+                issuerErrorCode: e.issuerErrorCode,
+                issuerErrorDescription: e.issuerErrorDescription,
                 cause: e
             )
 
@@ -194,8 +194,8 @@ class CredentialRequestExecutor {
 
             throw DownloadFailedException(
                 message: e.message,
-                serverErrorCode: e.serverErrorCode,
-                serverErrorDescription: e.serverErrorDescription,
+                issuerErrorCode: e.issuerErrorCode,
+                issuerErrorDescription: e.issuerErrorDescription,
                 cause: e
             )
 

--- a/Sources/VCIClient/credentialOffer/CredentialOfferService.swift
+++ b/Sources/VCIClient/credentialOffer/CredentialOfferService.swift
@@ -43,8 +43,8 @@ class CredentialOfferService {
         } catch let e as VCIClientException {
             throw CredentialOfferFetchFailedException(
                 e.message,
-                serverErrorCode: e.serverErrorCode,
-                serverErrorDescription: e.serverErrorDescription,
+                issuerErrorCode: e.issuerErrorCode,
+                issuerErrorDescription: e.issuerErrorDescription,
                 cause: e
             )
 

--- a/Sources/VCIClient/exceptions/AuthorizationServerDiscoveryException.swift
+++ b/Sources/VCIClient/exceptions/AuthorizationServerDiscoveryException.swift
@@ -10,15 +10,15 @@ class AuthorizationServerDiscoveryException: VCIClientException {
 
     init(
         message: String?,
-        serverErrorCode: String? = nil,
-        serverErrorDescription: String? = nil,
+        issuerErrorCode: String? = nil,
+        issuerErrorDescription: String? = nil,
         cause: Error? = nil
     ) {
         super.init(
             code: "VCI-001",
             message: "Failed to discover authorization server: \(message ?? "")",
-            serverErrorCode: serverErrorCode,
-            serverErrorDescription: serverErrorDescription,
+            issuerErrorCode: issuerErrorCode,
+            issuerErrorDescription: issuerErrorDescription,
             cause: cause
         )
     }

--- a/Sources/VCIClient/exceptions/CredentialOfferFetchFailedException.swift
+++ b/Sources/VCIClient/exceptions/CredentialOfferFetchFailedException.swift
@@ -10,15 +10,15 @@ class CredentialOfferFetchFailedException: VCIClientException {
     
     init(
         _ message: String?,
-        serverErrorCode: String? = nil,
-        serverErrorDescription: String? = nil,
+        issuerErrorCode: String? = nil,
+        issuerErrorDescription: String? = nil,
         cause: Error? = nil
     ) {
         super.init(
             code: "VCI-008",
             message: "Failed to fetch credential offer: \(message ?? "")",
-            serverErrorCode: serverErrorCode,
-            serverErrorDescription: serverErrorDescription,
+            issuerErrorCode: issuerErrorCode,
+            issuerErrorDescription: issuerErrorDescription,
             cause: cause
         )
     }

--- a/Sources/VCIClient/exceptions/DownloadFailedException.swift
+++ b/Sources/VCIClient/exceptions/DownloadFailedException.swift
@@ -10,15 +10,15 @@ class DownloadFailedException: VCIClientException {
     
     init(
         message: String?,
-        serverErrorCode: String? = nil,
-        serverErrorDescription: String? = nil,
+        issuerErrorCode: String? = nil,
+        issuerErrorDescription: String? = nil,
         cause: Error? = nil
     ) {
         super.init(
             code: "VCI-002",
             message: "Failed to download Credential: \(message ?? "")",
-            serverErrorCode: serverErrorCode,
-            serverErrorDescription: serverErrorDescription,
+            issuerErrorCode: issuerErrorCode,
+            issuerErrorDescription: issuerErrorDescription,
             cause: cause
         )
     }

--- a/Sources/VCIClient/exceptions/IllegalArgumentException.swift
+++ b/Sources/VCIClient/exceptions/IllegalArgumentException.swift
@@ -10,15 +10,15 @@ class IllegalArgumentException: VCIClientException {
     
     init(
         message: String?,
-        serverErrorCode: String? = nil,
-        serverErrorDescription: String? = nil,
+        issuerErrorCode: String? = nil,
+        issuerErrorDescription: String? = nil,
         cause: Error? = nil
     ) {
         super.init(
             code: "VCI-012",
             message: message ?? "An illegal argument was provided.",
-            serverErrorCode: serverErrorCode,
-            serverErrorDescription: serverErrorDescription,
+            issuerErrorCode: issuerErrorCode,
+            issuerErrorDescription: issuerErrorDescription,
             cause: cause
         )
     }

--- a/Sources/VCIClient/exceptions/InteractiveAuthorizationException.swift
+++ b/Sources/VCIClient/exceptions/InteractiveAuthorizationException.swift
@@ -10,15 +10,15 @@ class InteractiveAuthorizationException: VCIClientException {
     }
     init(
         message: String?,
-        serverErrorCode: String? = nil,
-        serverErrorDescription: String? = nil,
+        issuerErrorCode: String? = nil,
+        issuerErrorDescription: String? = nil,
         cause: Error? = nil
     ) {
         super.init(
             code: "VCI-011",
             message: "Failed to authorize via interaction: \(message ?? "")",
-            serverErrorCode: serverErrorCode,
-            serverErrorDescription: serverErrorDescription,
+            issuerErrorCode: issuerErrorCode,
+            issuerErrorDescription: issuerErrorDescription,
             cause: cause
         )
     }

--- a/Sources/VCIClient/exceptions/InvalidAccessTokenException.swift
+++ b/Sources/VCIClient/exceptions/InvalidAccessTokenException.swift
@@ -10,15 +10,15 @@ class InvalidAccessTokenException: VCIClientException {
     
     init(
         message: String?,
-        serverErrorCode: String? = nil,
-        serverErrorDescription: String? = nil,
+        issuerErrorCode: String? = nil,
+        issuerErrorDescription: String? = nil,
         cause: Error? = nil
     ) {
         super.init(
             code: "VCI-003",
             message: "Access token is invalid : \(message ?? "")",
-            serverErrorCode: serverErrorCode,
-            serverErrorDescription: serverErrorDescription,
+            issuerErrorCode: issuerErrorCode,
+            issuerErrorDescription: issuerErrorDescription,
             cause: cause
         )
     }

--- a/Sources/VCIClient/exceptions/InvalidDataProvidedException.swift
+++ b/Sources/VCIClient/exceptions/InvalidDataProvidedException.swift
@@ -10,15 +10,15 @@ class InvalidDataProvidedException: VCIClientException {
     
     init(
         message: String?,
-        serverErrorCode: String? = nil,
-        serverErrorDescription: String? = nil,
+        issuerErrorCode: String? = nil,
+        issuerErrorDescription: String? = nil,
         cause: Error? = nil
     ) {
         super.init(
             code: "VCI-004",
             message: "Required details not provided : \(message ?? "")",
-            serverErrorCode: serverErrorCode,
-            serverErrorDescription: serverErrorDescription,
+            issuerErrorCode: issuerErrorCode,
+            issuerErrorDescription: issuerErrorDescription,
             cause: cause
         )
     }

--- a/Sources/VCIClient/exceptions/InvalidPublicKeyException.swift
+++ b/Sources/VCIClient/exceptions/InvalidPublicKeyException.swift
@@ -10,15 +10,15 @@ class InvalidPublicKeyException: VCIClientException {
     
     init(
         message: String?,
-        serverErrorCode: String? = nil,
-        serverErrorDescription: String? = nil,
+        issuerErrorCode: String? = nil,
+        issuerErrorDescription: String? = nil,
         cause: Error? = nil
     ) {
         super.init(
             code: "VCI-005",
             message: "Invalid public key passed: \(message ?? "")",
-            serverErrorCode: serverErrorCode,
-            serverErrorDescription: serverErrorDescription,
+            issuerErrorCode: issuerErrorCode,
+            issuerErrorDescription: issuerErrorDescription,
             cause: cause
         )
     }

--- a/Sources/VCIClient/exceptions/IssuerMetadataFetchException.swift
+++ b/Sources/VCIClient/exceptions/IssuerMetadataFetchException.swift
@@ -10,15 +10,15 @@ class IssuerMetadataFetchException: VCIClientException {
 
     init(
         _ message: String?,
-        serverErrorCode: String? = nil,
-        serverErrorDescription: String? = nil,
+        issuerErrorCode: String? = nil,
+        issuerErrorDescription: String? = nil,
         cause: Error? = nil
     ) {
         super.init(
             code: "VCI-009",
             message: "Failed to fetch issuerMetadata: \(message ?? "")",
-            serverErrorCode: serverErrorCode,
-            serverErrorDescription: serverErrorDescription,
+            issuerErrorCode: issuerErrorCode,
+            issuerErrorDescription: issuerErrorDescription,
             cause: cause
         )
     }

--- a/Sources/VCIClient/exceptions/NetworkRequestFailedException.swift
+++ b/Sources/VCIClient/exceptions/NetworkRequestFailedException.swift
@@ -10,15 +10,15 @@ class NetworkRequestFailedException: VCIClientException {
 
     init(
         message: String?,
-        serverErrorCode: String? = nil,
-        serverErrorDescription: String? = nil,
+        issuerErrorCode: String? = nil,
+        issuerErrorDescription: String? = nil,
         cause: Error? = nil
     ) {
         super.init(
             code: "VCI-006",
             message: "Network request failed, details - \(message ?? "")",
-            serverErrorCode: serverErrorCode,
-            serverErrorDescription: serverErrorDescription,
+            issuerErrorCode: issuerErrorCode,
+            issuerErrorDescription: issuerErrorDescription,
             cause: cause
         )
     }

--- a/Sources/VCIClient/exceptions/NetworkRequestTimeoutException.swift
+++ b/Sources/VCIClient/exceptions/NetworkRequestTimeoutException.swift
@@ -10,15 +10,15 @@ class NetworkRequestTimeoutException: VCIClientException {
     
     init(
             message: String?,
-            serverErrorCode: String? = nil,
-            serverErrorDescription: String? = nil,
+            issuerErrorCode: String? = nil,
+            issuerErrorDescription: String? = nil,
             cause: Error? = nil
         ) {
             super.init(
                 code: "VCI-007",
                 message: "Network request timeout - \(message ?? "")",
-                serverErrorCode: serverErrorCode,
-                serverErrorDescription: serverErrorDescription,
+                issuerErrorCode: issuerErrorCode,
+                issuerErrorDescription: issuerErrorDescription,
                 cause: cause
             )
         }

--- a/Sources/VCIClient/exceptions/VCIClientException.swift
+++ b/Sources/VCIClient/exceptions/VCIClientException.swift
@@ -4,18 +4,16 @@ public class VCIClientException: Error, LocalizedError {
 
     public let code: String
     public let message: String
-    public let sourceErrorCode: String?
-    public let serverErrorCode: String?
-    public let serverErrorDescription: String?
+    public let issuerErrorCode: String?
+    public let issuerErrorDescription: String?
     public let cause: Error?
 
     public init(code: String, message: String) {
         self.code = code
         self.message = message
-        self.serverErrorCode = nil
-        self.serverErrorDescription = nil
+        self.issuerErrorCode = nil
+        self.issuerErrorDescription = nil
         self.cause = nil
-        self.sourceErrorCode = nil
 
         Util.logError(
             message: "Exception occurred with code: \(code), message: \(message)",
@@ -26,16 +24,15 @@ public class VCIClientException: Error, LocalizedError {
     public init(
         code: String,
         message: String,
-        serverErrorCode: String? = nil,
-        serverErrorDescription: String? = nil,
+        issuerErrorCode: String? = nil,
+        issuerErrorDescription: String? = nil,
         cause: Error? = nil
     ) {
-        self.code = code
+        self.code = VCIClientException.extractRootCode(from: cause) ?? code
         self.message = message
-        self.serverErrorCode = serverErrorCode
-        self.serverErrorDescription = serverErrorDescription
+        self.issuerErrorCode = issuerErrorCode
+        self.issuerErrorDescription = issuerErrorDescription
         self.cause = cause
-        self.sourceErrorCode = VCIClientException.extractRootCode(from: cause)
 
         Util.logError(
             message: "Exception occurred with code: \(code), message: \(message)",

--- a/Sources/VCIClient/issuerMetadata/IssuerMetadataService.swift
+++ b/Sources/VCIClient/issuerMetadata/IssuerMetadataService.swift
@@ -36,8 +36,8 @@ class IssuerMetadataService {
         } catch let e as VCIClientException {
             throw IssuerMetadataFetchException(
                 e.message,
-                serverErrorCode: e.serverErrorCode,
-                serverErrorDescription: e.serverErrorDescription,
+                issuerErrorCode: e.issuerErrorCode,
+                issuerErrorDescription: e.issuerErrorDescription,
                 cause: e
             )
         } catch {
@@ -75,8 +75,8 @@ class IssuerMetadataService {
         } catch let e as VCIClientException {
             throw IssuerMetadataFetchException(
                 e.message,
-                serverErrorCode: e.serverErrorCode,
-                serverErrorDescription: e.serverErrorDescription,
+                issuerErrorCode: e.issuerErrorCode,
+                issuerErrorDescription: e.issuerErrorDescription,
                 cause: e
             )
         } catch {

--- a/Sources/VCIClient/networkManager/NetworkManager.swift
+++ b/Sources/VCIClient/networkManager/NetworkManager.swift
@@ -76,13 +76,13 @@ class NetworkManager {
             let body = String(data: data, encoding: .utf8) ?? ""
 
             guard (200 ... 299).contains(httpResponse.statusCode) else {
-                let (serverErrorCode, serverErrorDescription) =
+                let (issuerErrorCode, issuerErrorDescription) =
                     parseServerErrorResponse(body)
 
                 throw NetworkRequestFailedException(
                     message: "HTTP \(httpResponse.statusCode)",
-                    serverErrorCode: serverErrorCode,
-                    serverErrorDescription: serverErrorDescription
+                    issuerErrorCode: issuerErrorCode,
+                    issuerErrorDescription: issuerErrorDescription
                 )
             }
 

--- a/Sources/VCIClient/preAuthCodeFlow/PreAuthCodeFlowService.swift
+++ b/Sources/VCIClient/preAuthCodeFlow/PreAuthCodeFlowService.swift
@@ -163,8 +163,8 @@ class PreAuthCodeFlowService {
         } catch let e as VCIClientException {
             throw DownloadFailedException(
                 message: "Pre-Authorized Code Flow failed: \(e.message)",
-                serverErrorCode: e.serverErrorCode,
-                serverErrorDescription: e.serverErrorDescription,
+                issuerErrorCode: e.issuerErrorCode,
+                issuerErrorDescription: e.issuerErrorDescription,
                 cause: e
             )
         } catch {

--- a/Tests/VCIClientTests/VCIClientTests.swift
+++ b/Tests/VCIClientTests/VCIClientTests.swift
@@ -34,7 +34,7 @@ final class VCIClientTests: XCTestCase {
 
         await assertThrowsVCIErrorContainingMessage(
             expectedType: VCIClientException.self,
-            expectedCode: "VCI-010",
+            expectedCode: "VCI-002",
             messageContains: "Simulated failure"
         ) {
             try await client.fetchCredentialsUsingCredentialOffer(
@@ -82,7 +82,7 @@ final class VCIClientTests: XCTestCase {
 
         await assertThrowsVCIErrorContainingMessage(
             expectedType: VCIClientException.self,
-            expectedCode: "VCI-010",
+            expectedCode: "VCI-002",
             messageContains: "Simulated failure"
         ) {
             try await client.fetchCredentialsFromTrustedIssuer(
@@ -130,7 +130,7 @@ final class VCIClientTests: XCTestCase {
 
         await assertThrowsVCIErrorContainingMessage(
             expectedType: VCIClientException.self,
-            expectedCode: "VCI-010",
+            expectedCode: "VCI-009",
             messageContains: "Mock error"
         ) {
             try await client.getIssuerMetadata(credentialIssuer: "https://issuer.example.com")
@@ -169,7 +169,7 @@ final class VCIClientTests: XCTestCase {
 
         _ = await assertThrowsVCIErrorContainingMessage(
             expectedType: VCIClientException.self,
-            expectedCode: "VCI-010",
+            expectedCode: "VCI-009",
             messageContains: "Simulated failure"
         ) {
             try await client.getCredentialConfigurationsSupported(

--- a/Tests/VCIClientTests/exceptions/VCIClientExceptionTests.swift
+++ b/Tests/VCIClientTests/exceptions/VCIClientExceptionTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import VCIClient
+
+final class VCIClientExceptionTests: XCTestCase {
+
+    func testCodeRetainsRootCodeFromNestedException() {
+        let root = AuthorizationServerDiscoveryException("resolver failure")
+        let wrapped = NetworkRequestFailedException(
+            message: "token endpoint failed",
+            issuerErrorCode: "server_error",
+            issuerErrorDescription: "temporary issue",
+            cause: root
+        )
+
+        XCTAssertEqual("VCI-001", wrapped.code)
+        XCTAssertEqual("server_error", wrapped.issuerErrorCode)
+        XCTAssertEqual("temporary issue", wrapped.issuerErrorDescription)
+    }
+
+    func testCodeResolvesToDeepestRootCodeAcrossMultiLevelChain() {
+        let root = InvalidDataProvidedException("missing field")
+        let mid = AuthorizationServerDiscoveryException(
+            message: "discovery failed",
+            cause: root
+        )
+        let outer = NetworkRequestFailedException(
+            message: "token endpoint failed",
+            cause: mid
+        )
+
+        XCTAssertEqual("VCI-004", outer.code)
+    }
+
+    func testCodeFallsBackToOwnCodeWhenNoVciCause() {
+        let exception = NetworkRequestFailedException("connection reset")
+
+        XCTAssertEqual("VCI-006", exception.code)
+        XCTAssertNil(exception.issuerErrorCode)
+        XCTAssertNil(exception.issuerErrorDescription)
+    }
+}

--- a/Tests/VCIClientTests/mocks/MockServices.swift
+++ b/Tests/VCIClientTests/mocks/MockServices.swift
@@ -319,7 +319,7 @@ class MockInteractiveAuthorizationHandler: InteractiveAuthorizationHandler {
             throw errorToThrow
         }
         if shouldThrowMissingInteractionType {
-            throw DownloadFailedException(message: "dummy", serverErrorCode: "missing_interaction_type")
+            throw DownloadFailedException(message: "dummy", issuerErrorCode: "missing_interaction_type")
         }
         return responseToReturn
     }

--- a/Tests/VCIClientTests/networkManager/NetworkManagerTests.swift
+++ b/Tests/VCIClientTests/networkManager/NetworkManagerTests.swift
@@ -260,8 +260,8 @@ final class NetworkManagerTests: XCTestCase {
             )
             XCTFail("Expected HTTP error")
         } catch let error as NetworkRequestFailedException {
-            XCTAssertEqual(error.serverErrorCode, "invalid_request")
-            XCTAssertEqual(error.serverErrorDescription, "missing proof")
+            XCTAssertEqual(error.issuerErrorCode, "invalid_request")
+            XCTAssertEqual(error.issuerErrorDescription, "missing proof")
         } catch {
             XCTFail("Unexpected error type: \(error)")
         }


### PR DESCRIPTION
Drops the separate `sourceErrorCode` on `VCIClientException`; the single `code` now carries the root error code resolved from the cause chain. Renames `serverErrorCode`/`serverErrorDescription` to `issuerErrorCode`/`issuerErrorDescription` across exceptions, callers and tests. Mirrors the corresponding Android change.