### PR TITLE
feat(ios): add Pushed Authorization Request (PAR) support

### DIFF
--- a/.github/workflows/push-trigger.yml
+++ b/.github/workflows/push-trigger.yml
@@ -32,7 +32,7 @@ jobs:
         run: xcodebuild -scheme VCIClient -destination 'generic/platform=iOS' build
 
       - name: Run tests
-        run: xcodebuild test -scheme VCIClientTests -destination 'platform=iOS Simulator,OS=17.5,name=iPhone 15'
+        run: xcodebuild test -scheme VCIClientTests -destination 'platform=iOS Simulator,OS=latest,name=iPhone 15'
 
       - name: Notify on Slack
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/push-trigger.yml
+++ b/.github/workflows/push-trigger.yml
@@ -32,7 +32,7 @@ jobs:
         run: xcodebuild -scheme VCIClient -destination 'generic/platform=iOS' build
 
       - name: Run tests
-        run: xcodebuild test -scheme VCIClientTests -destination 'platform=iOS Simulator,OS=latest,name=iPhone 15'
+        run: xcodebuild test -scheme VCIClientTests -destination 'platform=iOS Simulator,OS=17.5,name=iPhone 15'
 
       - name: Notify on Slack
         uses: 8398a7/action-slack@v3

--- a/README.md
+++ b/README.md
@@ -589,7 +589,8 @@ do {
 | VCI-009 | `IssuerMetadataFetchException`          | Failed to fetch issuerMetadata                                                                           |
 | VCI-010 | `VCIClientException`                    | Generic API-boundary wrapper or unknown exception surfaced by `VCIClient` public methods                 |
 | VCI-011 | `InteractiveAuthorizationException`     | Failed to perform Interactive authorization (Presentation During Issuance / Redirect to Web interaction) |
-| VCI-012 | `PushedAuthorizationRequestException`   | Failed to push authorization request (RFC 9126)                                                          |
+| VCI-012 | `IllegalArgumentException`              | Invalid or missing argument in a request or response payload                                             |
+| VCI-013 | `PushedAuthorizationRequestException`   | Failed to push authorization request (RFC 9126)                                                          |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ The implementation follows
 - Authorization server discovery for both flows
 - PKCE-compliant OAuth 2.0 Authorization Code flow (RFC 7636)
   - PKCE session is managed internally by the library
+- Pushed Authorization Requests (PAR) support (RFC 9126)
+  - Used automatically when the authorization server advertises a `pushed_authorization_request_endpoint`
+  - Falls back to a standard authorization request if the push fails and PAR is not mandated by the authorization server
 - Well-defined **exception handling** with `VCI-XXX` error codes (see more on [this](#-error-handling))
 - Support for multiple Credential formats:
   - `ldp_vc`
@@ -494,6 +497,7 @@ do {
 | VCI-009 | `IssuerMetadataFetchException`             | Failed to fetch issuerMetadata                                                                           |
 | VCI-010 | `VCIClientException`                       | Generic API-boundary wrapper or unknown exception surfaced by `VCIClient` public methods                |
 | VCI-011 | `InteractiveAuthorizationException`        | Failed to perform Interactive authorization (Presentation During Issuance / Redirect to Web interaction) |
+| VCI-012 | `PushedAuthorizationRequestException`      | Failed to push authorization request (RFC 9126)                                                          |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -590,7 +590,8 @@ do {
 | VCI-010 | `VCIClientException`                    | Generic API-boundary wrapper or unknown exception surfaced by `VCIClient` public methods                 |
 | VCI-011 | `InteractiveAuthorizationException`     | Failed to perform Interactive authorization (Presentation During Issuance / Redirect to Web interaction) |
 | VCI-012 | `IllegalArgumentException`              | Invalid or missing argument in a request or response payload                                             |
-| VCI-013 | `PushedAuthorizationRequestException`   | Failed to push authorization request (RFC 9126)                                                          |
+| VCI-013 | `DPoPException`                         | Failed to generate or apply DPoP proof (RFC 9449)                                                        |
+| VCI-014 | `PushedAuthorizationRequestException`   | Failed to push authorization request (RFC 9126)                                                          |
 
 ---
 

--- a/Sources/VCIClient/authorizationCodeFlow/AuthorizationCodeFlowService.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/AuthorizationCodeFlowService.swift
@@ -133,8 +133,6 @@ class AuthorizationCodeFlowService {
         do {
             let pkceSession = pkceSessionManager.createSession()
 
-            let issuerState = credentialOffer?.grants?.authorizationCodeGrant?.issuerState
-
             let authServerMetadata: AuthorizationServerMetadata
             do {
                 authServerMetadata = try await authServerResolver.resolveForAuthCode(
@@ -160,8 +158,7 @@ class AuthorizationCodeFlowService {
                     authorizationMethods: authorizationMethods,
                     pkceSession: pkceSession,
                     getTokenResponse: getTokenResponse,
-                    credentialConfigurationId: credentialConfigurationId,
-                    issuerState: issuerState
+                    credentialConfigurationId: credentialConfigurationId
                 )
             } catch let e as DownloadFailedException {
                 throw e
@@ -205,14 +202,13 @@ class AuthorizationCodeFlowService {
         authorizationMethods: [AuthorizationMethod],
         pkceSession: PKCESessionManager.PKCESession,
         getTokenResponse: @escaping TokenResponseCallback,
-        credentialConfigurationId: String,
-        issuerState: String? = nil
+        credentialConfigurationId: String
     ) async throws -> TokenResponse {
         guard let tokenEndpoint = issuerMetadata.tokenEndpoint ?? authServerMetadata.tokenEndpoint else {
             throw DownloadFailedException("Missing token endpoint for issuer \(issuerMetadata.credentialIssuer)")
         }
 
-        let authCode = try await obtainAuthorizationCode(authorizationServerMetadata: authServerMetadata, issuerMetadata: issuerMetadata, clientMetadata: clientMetadata, pkceSession: pkceSession, credentialConfigurationId: credentialConfigurationId, authorizationMethods: authorizationMethods, issuerState: issuerState)
+        let authCode = try await obtainAuthorizationCode(authorizationServerMetadata: authServerMetadata, issuerMetadata: issuerMetadata, clientMetadata: clientMetadata, pkceSession: pkceSession, credentialConfigurationId: credentialConfigurationId, authorizationMethods: authorizationMethods)
 
         return try await tokenService.getAccessToken(
             getTokenResponse: getTokenResponse,
@@ -230,8 +226,7 @@ class AuthorizationCodeFlowService {
         clientMetadata: ClientMetadata,
         pkceSession: PKCESessionManager.PKCESession,
         credentialConfigurationId: String,
-        authorizationMethods: [AuthorizationMethod],
-        issuerState: String? = nil
+        authorizationMethods: [AuthorizationMethod]
     ) async throws -> String {
     
         let normalizedInteractiveEndpoint =
@@ -267,8 +262,7 @@ class AuthorizationCodeFlowService {
                         issuerMetadata: issuerMetadata,
                         clientMetadata: clientMetadata,
                         pkceSession: pkceSession,
-                        authorizationMethods: authorizationMethods,
-                        issuerState: issuerState
+                        authorizationMethods: authorizationMethods
                     )
                 }
 
@@ -281,8 +275,7 @@ class AuthorizationCodeFlowService {
                 issuerMetadata: issuerMetadata,
                 clientMetadata: clientMetadata,
                 pkceSession: pkceSession,
-                authorizationMethods: authorizationMethods,
-                issuerState: issuerState
+                authorizationMethods: authorizationMethods
             )
         }
     }
@@ -331,8 +324,7 @@ class AuthorizationCodeFlowService {
         issuerMetadata: IssuerMetadata,
         clientMetadata: ClientMetadata,
         pkceSession: PKCESessionManager.PKCESession,
-        authorizationMethods: [AuthorizationMethod]? = nil,
-        issuerState: String? = nil
+        authorizationMethods: [AuthorizationMethod]? = nil
     ) async throws -> String {
         guard let authorizationEndpoint =
             authorizationServerMetadata.authorizationEndpoint else {
@@ -355,8 +347,7 @@ class AuthorizationCodeFlowService {
                 clientMetadata: clientMetadata,
                 pkceSession: pkceSession,
                 scope: issuerMetadata.scope ?? "default",
-                pushedAuthorizationRequestEndpoint: authorizationServerMetadata.pushedAuthorizationRequestEndpoint,
-                issuerState: issuerState
+                pushedAuthorizationRequestEndpoint: authorizationServerMetadata.pushedAuthorizationRequestEndpoint
             )
 
             let response: AuthorizationResponse

--- a/Sources/VCIClient/authorizationCodeFlow/AuthorizationCodeFlowService.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/AuthorizationCodeFlowService.swift
@@ -372,9 +372,7 @@ class AuthorizationCodeFlowService {
                 pkceSession: pkceSession,
                 scope: issuerMetadata.scope ?? "default",
                 pushedAuthorizationRequestEndpoint: authorizationServerMetadata.pushedAuthorizationRequestEndpoint,
-                dpopJkt: try dpopManager.jwkThumbprint(),
-                tokenEndpointAuthMethodsSupported: authorizationServerMetadata.tokenEndpointAuthMethodsSupported,
-                requirePushedAuthorizationRequests: authorizationServerMetadata.requirePushedAuthorizationRequests
+                dpopJkt: try dpopManager.jwkThumbprint()
             )
 
             let response: AuthorizationResponse

--- a/Sources/VCIClient/authorizationCodeFlow/AuthorizationCodeFlowService.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/AuthorizationCodeFlowService.swift
@@ -381,13 +381,6 @@ class AuthorizationCodeFlowService {
                 response = try await RedirectToWebAuthorizationMethodService(
                     openWebPage: openWebPage
                 ).authorizeUser(requestData: requestData)
-            } catch let e as VCIClientException {
-                throw DownloadFailedException(
-                    message: "Authorization failed at authorization endpoint \(authorizationEndpoint): \(e.localizedDescription)",
-                    issuerErrorCode: e.issuerErrorCode,
-                    issuerErrorDescription: e.issuerErrorDescription,
-                    cause: e
-                )
             } catch {
                 throw DownloadFailedException(
                     "Authorization failed at authorization endpoint \(authorizationEndpoint): \(error.localizedDescription)"

--- a/Sources/VCIClient/authorizationCodeFlow/AuthorizationCodeFlowService.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/AuthorizationCodeFlowService.swift
@@ -372,6 +372,7 @@ class AuthorizationCodeFlowService {
                 pkceSession: pkceSession,
                 scope: issuerMetadata.scope ?? "default",
                 pushedAuthorizationRequestEndpoint: authorizationServerMetadata.pushedAuthorizationRequestEndpoint,
+                requirePushedAuthorizationRequests: authorizationServerMetadata.requirePushedAuthorizationRequests,
                 dpopJkt: try dpopManager.jwkThumbprint()
             )
 

--- a/Sources/VCIClient/authorizationCodeFlow/AuthorizationCodeFlowService.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/AuthorizationCodeFlowService.swift
@@ -372,7 +372,9 @@ class AuthorizationCodeFlowService {
                 pkceSession: pkceSession,
                 scope: issuerMetadata.scope ?? "default",
                 pushedAuthorizationRequestEndpoint: authorizationServerMetadata.pushedAuthorizationRequestEndpoint,
-                dpopJkt: try dpopManager.jwkThumbprint()
+                dpopJkt: try dpopManager.jwkThumbprint(),
+                tokenEndpointAuthMethodsSupported: authorizationServerMetadata.tokenEndpointAuthMethodsSupported,
+                requirePushedAuthorizationRequests: authorizationServerMetadata.requirePushedAuthorizationRequests
             )
 
             let response: AuthorizationResponse

--- a/Sources/VCIClient/authorizationCodeFlow/AuthorizationCodeFlowService.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/AuthorizationCodeFlowService.swift
@@ -364,6 +364,13 @@ class AuthorizationCodeFlowService {
                 response = try await RedirectToWebAuthorizationMethodService(
                     openWebPage: openWebPage
                 ).authorizeUser(requestData: requestData)
+            } catch let e as VCIClientException {
+                throw DownloadFailedException(
+                    message: "Authorization failed at authorization endpoint \(authorizationEndpoint): \(e.localizedDescription)",
+                    issuerErrorCode: e.issuerErrorCode,
+                    issuerErrorDescription: e.issuerErrorDescription,
+                    cause: e
+                )
             } catch {
                 throw DownloadFailedException(
                     "Authorization failed at authorization endpoint \(authorizationEndpoint): \(error.localizedDescription)"

--- a/Sources/VCIClient/authorizationCodeFlow/AuthorizationCodeFlowService.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/AuthorizationCodeFlowService.swift
@@ -133,6 +133,8 @@ class AuthorizationCodeFlowService {
         do {
             let pkceSession = pkceSessionManager.createSession()
 
+            let issuerState = credentialOffer?.grants?.authorizationCodeGrant?.issuerState
+
             let authServerMetadata: AuthorizationServerMetadata
             do {
                 authServerMetadata = try await authServerResolver.resolveForAuthCode(
@@ -158,7 +160,8 @@ class AuthorizationCodeFlowService {
                     authorizationMethods: authorizationMethods,
                     pkceSession: pkceSession,
                     getTokenResponse: getTokenResponse,
-                    credentialConfigurationId: credentialConfigurationId
+                    credentialConfigurationId: credentialConfigurationId,
+                    issuerState: issuerState
                 )
             } catch let e as DownloadFailedException {
                 throw e
@@ -202,13 +205,14 @@ class AuthorizationCodeFlowService {
         authorizationMethods: [AuthorizationMethod],
         pkceSession: PKCESessionManager.PKCESession,
         getTokenResponse: @escaping TokenResponseCallback,
-        credentialConfigurationId: String
+        credentialConfigurationId: String,
+        issuerState: String? = nil
     ) async throws -> TokenResponse {
         guard let tokenEndpoint = issuerMetadata.tokenEndpoint ?? authServerMetadata.tokenEndpoint else {
             throw DownloadFailedException("Missing token endpoint for issuer \(issuerMetadata.credentialIssuer)")
         }
 
-        let authCode = try await obtainAuthorizationCode(authorizationServerMetadata: authServerMetadata, issuerMetadata: issuerMetadata, clientMetadata: clientMetadata, pkceSession: pkceSession, credentialConfigurationId: credentialConfigurationId, authorizationMethods: authorizationMethods)
+        let authCode = try await obtainAuthorizationCode(authorizationServerMetadata: authServerMetadata, issuerMetadata: issuerMetadata, clientMetadata: clientMetadata, pkceSession: pkceSession, credentialConfigurationId: credentialConfigurationId, authorizationMethods: authorizationMethods, issuerState: issuerState)
 
         return try await tokenService.getAccessToken(
             getTokenResponse: getTokenResponse,
@@ -226,7 +230,8 @@ class AuthorizationCodeFlowService {
         clientMetadata: ClientMetadata,
         pkceSession: PKCESessionManager.PKCESession,
         credentialConfigurationId: String,
-        authorizationMethods: [AuthorizationMethod]
+        authorizationMethods: [AuthorizationMethod],
+        issuerState: String? = nil
     ) async throws -> String {
     
         let normalizedInteractiveEndpoint =
@@ -262,7 +267,8 @@ class AuthorizationCodeFlowService {
                         issuerMetadata: issuerMetadata,
                         clientMetadata: clientMetadata,
                         pkceSession: pkceSession,
-                        authorizationMethods: authorizationMethods
+                        authorizationMethods: authorizationMethods,
+                        issuerState: issuerState
                     )
                 }
 
@@ -275,7 +281,8 @@ class AuthorizationCodeFlowService {
                 issuerMetadata: issuerMetadata,
                 clientMetadata: clientMetadata,
                 pkceSession: pkceSession,
-                authorizationMethods: authorizationMethods
+                authorizationMethods: authorizationMethods,
+                issuerState: issuerState
             )
         }
     }
@@ -324,7 +331,8 @@ class AuthorizationCodeFlowService {
         issuerMetadata: IssuerMetadata,
         clientMetadata: ClientMetadata,
         pkceSession: PKCESessionManager.PKCESession,
-        authorizationMethods: [AuthorizationMethod]? = nil
+        authorizationMethods: [AuthorizationMethod]? = nil,
+        issuerState: String? = nil
     ) async throws -> String {
         guard let authorizationEndpoint =
             authorizationServerMetadata.authorizationEndpoint else {
@@ -346,7 +354,9 @@ class AuthorizationCodeFlowService {
                 authorizeUrl: authorizationEndpoint,
                 clientMetadata: clientMetadata,
                 pkceSession: pkceSession,
-                scope: issuerMetadata.scope ?? "default"
+                scope: issuerMetadata.scope ?? "default",
+                pushedAuthorizationRequestEndpoint: authorizationServerMetadata.pushedAuthorizationRequestEndpoint,
+                issuerState: issuerState
             )
 
             let response: AuthorizationResponse

--- a/Sources/VCIClient/authorizationCodeFlow/ImplicitAuthorization/ImplicitAuthorizationRequestData.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/ImplicitAuthorization/ImplicitAuthorizationRequestData.swift
@@ -6,24 +6,18 @@ struct ImplicitAuthorizationRequestData: AuthorizationRequestData {
     let pkceSession: PKCESessionManager.PKCESession
     let scope: String
     let pushedAuthorizationRequestEndpoint: String?
-    let authorizationDetails: String?
-    let issuerState: String?
 
     init(
         authorizeUrl: String,
         clientMetadata: ClientMetadata,
         pkceSession: PKCESessionManager.PKCESession,
         scope: String,
-        pushedAuthorizationRequestEndpoint: String? = nil,
-        authorizationDetails: String? = nil,
-        issuerState: String? = nil
+        pushedAuthorizationRequestEndpoint: String? = nil
     ) {
         self.authorizeUrl = authorizeUrl
         self.clientMetadata = clientMetadata
         self.pkceSession = pkceSession
         self.scope = scope
         self.pushedAuthorizationRequestEndpoint = pushedAuthorizationRequestEndpoint
-        self.authorizationDetails = authorizationDetails
-        self.issuerState = issuerState
     }
 }

--- a/Sources/VCIClient/authorizationCodeFlow/ImplicitAuthorization/ImplicitAuthorizationRequestData.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/ImplicitAuthorization/ImplicitAuthorizationRequestData.swift
@@ -6,6 +6,7 @@ struct ImplicitAuthorizationRequestData: AuthorizationRequestData {
     let pkceSession: PKCESessionManager.PKCESession
     let scope: String
     let pushedAuthorizationRequestEndpoint: String?
+    let requirePushedAuthorizationRequests: Bool?
     let dpopJkt: String
 
     init(
@@ -14,6 +15,7 @@ struct ImplicitAuthorizationRequestData: AuthorizationRequestData {
         pkceSession: PKCESessionManager.PKCESession,
         scope: String,
         pushedAuthorizationRequestEndpoint: String? = nil,
+        requirePushedAuthorizationRequests: Bool? = nil,
         dpopJkt: String
     ) {
         self.authorizeUrl = authorizeUrl
@@ -21,6 +23,7 @@ struct ImplicitAuthorizationRequestData: AuthorizationRequestData {
         self.pkceSession = pkceSession
         self.scope = scope
         self.pushedAuthorizationRequestEndpoint = pushedAuthorizationRequestEndpoint
+        self.requirePushedAuthorizationRequests = requirePushedAuthorizationRequests
         self.dpopJkt = dpopJkt
     }
 }

--- a/Sources/VCIClient/authorizationCodeFlow/ImplicitAuthorization/ImplicitAuthorizationRequestData.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/ImplicitAuthorization/ImplicitAuthorizationRequestData.swift
@@ -7,6 +7,8 @@ struct ImplicitAuthorizationRequestData: AuthorizationRequestData {
     let scope: String
     let pushedAuthorizationRequestEndpoint: String?
     let dpopJkt: String
+    let tokenEndpointAuthMethodsSupported: [String]?
+    let requirePushedAuthorizationRequests: Bool?
 
     init(
         authorizeUrl: String,
@@ -14,7 +16,9 @@ struct ImplicitAuthorizationRequestData: AuthorizationRequestData {
         pkceSession: PKCESessionManager.PKCESession,
         scope: String,
         pushedAuthorizationRequestEndpoint: String? = nil,
-        dpopJkt: String
+        dpopJkt: String,
+        tokenEndpointAuthMethodsSupported: [String]? = nil,
+        requirePushedAuthorizationRequests: Bool? = nil
     ) {
         self.authorizeUrl = authorizeUrl
         self.clientMetadata = clientMetadata
@@ -22,5 +26,7 @@ struct ImplicitAuthorizationRequestData: AuthorizationRequestData {
         self.scope = scope
         self.pushedAuthorizationRequestEndpoint = pushedAuthorizationRequestEndpoint
         self.dpopJkt = dpopJkt
+        self.tokenEndpointAuthMethodsSupported = tokenEndpointAuthMethodsSupported
+        self.requirePushedAuthorizationRequests = requirePushedAuthorizationRequests
     }
 }

--- a/Sources/VCIClient/authorizationCodeFlow/ImplicitAuthorization/ImplicitAuthorizationRequestData.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/ImplicitAuthorization/ImplicitAuthorizationRequestData.swift
@@ -7,8 +7,6 @@ struct ImplicitAuthorizationRequestData: AuthorizationRequestData {
     let scope: String
     let pushedAuthorizationRequestEndpoint: String?
     let dpopJkt: String
-    let tokenEndpointAuthMethodsSupported: [String]?
-    let requirePushedAuthorizationRequests: Bool?
 
     init(
         authorizeUrl: String,
@@ -16,9 +14,7 @@ struct ImplicitAuthorizationRequestData: AuthorizationRequestData {
         pkceSession: PKCESessionManager.PKCESession,
         scope: String,
         pushedAuthorizationRequestEndpoint: String? = nil,
-        dpopJkt: String,
-        tokenEndpointAuthMethodsSupported: [String]? = nil,
-        requirePushedAuthorizationRequests: Bool? = nil
+        dpopJkt: String
     ) {
         self.authorizeUrl = authorizeUrl
         self.clientMetadata = clientMetadata
@@ -26,7 +22,5 @@ struct ImplicitAuthorizationRequestData: AuthorizationRequestData {
         self.scope = scope
         self.pushedAuthorizationRequestEndpoint = pushedAuthorizationRequestEndpoint
         self.dpopJkt = dpopJkt
-        self.tokenEndpointAuthMethodsSupported = tokenEndpointAuthMethodsSupported
-        self.requirePushedAuthorizationRequests = requirePushedAuthorizationRequests
     }
 }

--- a/Sources/VCIClient/authorizationCodeFlow/ImplicitAuthorization/ImplicitAuthorizationRequestData.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/ImplicitAuthorization/ImplicitAuthorizationRequestData.swift
@@ -5,4 +5,25 @@ struct ImplicitAuthorizationRequestData: AuthorizationRequestData {
     let clientMetadata: ClientMetadata
     let pkceSession: PKCESessionManager.PKCESession
     let scope: String
+    let pushedAuthorizationRequestEndpoint: String?
+    let authorizationDetails: String?
+    let issuerState: String?
+
+    init(
+        authorizeUrl: String,
+        clientMetadata: ClientMetadata,
+        pkceSession: PKCESessionManager.PKCESession,
+        scope: String,
+        pushedAuthorizationRequestEndpoint: String? = nil,
+        authorizationDetails: String? = nil,
+        issuerState: String? = nil
+    ) {
+        self.authorizeUrl = authorizeUrl
+        self.clientMetadata = clientMetadata
+        self.pkceSession = pkceSession
+        self.scope = scope
+        self.pushedAuthorizationRequestEndpoint = pushedAuthorizationRequestEndpoint
+        self.authorizationDetails = authorizationDetails
+        self.issuerState = issuerState
+    }
 }

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/RedirectToWeb/RedirectToWebAuthorizationMethodService.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/RedirectToWeb/RedirectToWebAuthorizationMethodService.swift
@@ -25,33 +25,22 @@ final class RedirectToWebAuthorizationMethodService: AuthorizationMethodService 
             )
         }
 
+        let parEndpoint = request.pushedAuthorizationRequestEndpoint
+        let isParRequired = request.requirePushedAuthorizationRequests
+
         let authUrl: String
-        if let parEndpoint = request.pushedAuthorizationRequestEndpoint, !parEndpoint.isEmpty {
-            let parResponse = try await parService.pushAuthorizationRequest(
-                parEndpoint: parEndpoint,
-                clientId: request.clientMetadata.clientId,
-                redirectUri: request.clientMetadata.redirectUri,
-                codeChallenge: request.pkceSession.codeChallenge,
-                state: request.pkceSession.state,
-                nonce: request.pkceSession.nonce,
-                scope: request.scope
+        if let parEndpoint, !parEndpoint.isEmpty, isParRequired == true {
+            authUrl = try await buildAuthorizationUrlViaPushedRequest(
+                request: request,
+                parEndpoint: parEndpoint
             )
-            authUrl = AuthorizationUrlBuilder.buildWithRequestUri(
-                baseUrl: request.authorizeUrl,
-                clientId: request.clientMetadata.clientId,
-                requestUri: parResponse.requestUri
+        } else if let parEndpoint, !parEndpoint.isEmpty, isParRequired == nil {
+            authUrl = try await buildAuthorizationUrlViaPushedRequest(
+                request: request,
+                parEndpoint: parEndpoint
             )
         } else {
-            authUrl = AuthorizationUrlBuilder.buildWithParameters(
-                baseUrl: request.authorizeUrl,
-                clientId: request.clientMetadata.clientId,
-                redirectUri: request.clientMetadata.redirectUri,
-                scope: request.scope,
-                state: request.pkceSession.state,
-                codeChallenge: request.pkceSession.codeChallenge,
-                nonce: request.pkceSession.nonce,
-                dpopJkt: request.dpopJkt
-            )
+            authUrl = buildStandardAuthorizationUrl(request: request)
         }
 
         let authorizationResponse = try await openWebPage(authUrl)
@@ -78,6 +67,41 @@ final class RedirectToWebAuthorizationMethodService: AuthorizationMethodService 
             error: nil,
             errorDescription: nil,
             authSession: authorizationResponse["auth_session"] as? String
+        )
+    }
+
+    private func buildAuthorizationUrlViaPushedRequest(
+        request: ImplicitAuthorizationRequestData,
+        parEndpoint: String
+    ) async throws -> String {
+        let parResponse = try await parService.pushAuthorizationRequest(
+            parEndpoint: parEndpoint,
+            clientId: request.clientMetadata.clientId,
+            redirectUri: request.clientMetadata.redirectUri,
+            codeChallenge: request.pkceSession.codeChallenge,
+            state: request.pkceSession.state,
+            nonce: request.pkceSession.nonce,
+            scope: request.scope
+        )
+        return AuthorizationUrlBuilder.buildWithRequestUri(
+            baseUrl: request.authorizeUrl,
+            clientId: request.clientMetadata.clientId,
+            requestUri: parResponse.requestUri
+        )
+    }
+
+    private func buildStandardAuthorizationUrl(
+        request: ImplicitAuthorizationRequestData
+    ) -> String {
+        return AuthorizationUrlBuilder.buildWithParameters(
+            baseUrl: request.authorizeUrl,
+            clientId: request.clientMetadata.clientId,
+            redirectUri: request.clientMetadata.redirectUri,
+            scope: request.scope,
+            state: request.pkceSession.state,
+            codeChallenge: request.pkceSession.codeChallenge,
+            nonce: request.pkceSession.nonce,
+            dpopJkt: request.dpopJkt
         )
     }
 }

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/RedirectToWeb/RedirectToWebAuthorizationMethodService.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/RedirectToWeb/RedirectToWebAuthorizationMethodService.swift
@@ -26,13 +26,35 @@ final class RedirectToWebAuthorizationMethodService: AuthorizationMethodService 
         }
 
         let parEndpoint = request.pushedAuthorizationRequestEndpoint
+        let isParRequired = request.requirePushedAuthorizationRequests ?? false
 
         let authUrl: String
-        if let parEndpoint, !parEndpoint.isEmpty {
+        if isParRequired {
+            guard let parEndpoint, !parEndpoint.isEmpty else {
+                throw PushedAuthorizationRequestException(
+                    message: "Authorization server requires pushed authorization requests "
+                        + "but did not advertise a pushed_authorization_request_endpoint"
+                )
+            }
             authUrl = try await buildAuthorizationUrlViaPushedRequest(
                 request: request,
                 parEndpoint: parEndpoint
             )
+        } else if let parEndpoint, !parEndpoint.isEmpty {
+            do {
+                authUrl = try await buildAuthorizationUrlViaPushedRequest(
+                    request: request,
+                    parEndpoint: parEndpoint
+                )
+            } catch let error as PushedAuthorizationRequestException {
+                Util.logWarning(
+                    message: "PAR attempt failed at \(parEndpoint) and PAR is not required "
+                        + "by the authorization server, falling back to the standard "
+                        + "authorization request: \(error.message)",
+                    className: String(describing: type(of: self))
+                )
+                authUrl = buildStandardAuthorizationUrl(request: request)
+            }
         } else {
             authUrl = buildStandardAuthorizationUrl(request: request)
         }

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/RedirectToWeb/RedirectToWebAuthorizationMethodService.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/RedirectToWeb/RedirectToWebAuthorizationMethodService.swift
@@ -81,7 +81,8 @@ final class RedirectToWebAuthorizationMethodService: AuthorizationMethodService 
             codeChallenge: request.pkceSession.codeChallenge,
             state: request.pkceSession.state,
             nonce: request.pkceSession.nonce,
-            scope: request.scope
+            scope: request.scope,
+            dpopJkt: request.dpopJkt
         )
         return AuthorizationUrlBuilder.buildWithRequestUri(
             baseUrl: request.authorizeUrl,

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/RedirectToWeb/RedirectToWebAuthorizationMethodService.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/RedirectToWeb/RedirectToWebAuthorizationMethodService.swift
@@ -34,9 +34,7 @@ final class RedirectToWebAuthorizationMethodService: AuthorizationMethodService 
                 codeChallenge: request.pkceSession.codeChallenge,
                 state: request.pkceSession.state,
                 nonce: request.pkceSession.nonce,
-                scope: request.scope,
-                authorizationDetails: request.authorizationDetails,
-                issuerState: request.issuerState
+                scope: request.scope
             )
             authUrl = AuthorizationUrlBuilder.buildWithRequestUri(
                 baseUrl: request.authorizeUrl,
@@ -44,7 +42,7 @@ final class RedirectToWebAuthorizationMethodService: AuthorizationMethodService 
                 requestUri: parResponse.requestUri
             )
         } else {
-            authUrl = AuthorizationUrlBuilder.build(
+            authUrl = AuthorizationUrlBuilder.buildWithParameters(
                 baseUrl: request.authorizeUrl,
                 clientId: request.clientMetadata.clientId,
                 redirectUri: request.clientMetadata.redirectUri,

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/RedirectToWeb/RedirectToWebAuthorizationMethodService.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/RedirectToWeb/RedirectToWebAuthorizationMethodService.swift
@@ -46,11 +46,11 @@ final class RedirectToWebAuthorizationMethodService: AuthorizationMethodService 
                     request: request,
                     parEndpoint: parEndpoint
                 )
-            } catch let error as PushedAuthorizationRequestException {
+            } catch {
                 Util.logWarning(
                     message: "PAR attempt failed at \(parEndpoint) and PAR is not required "
                         + "by the authorization server, falling back to the standard "
-                        + "authorization request: \(error.message)",
+                        + "authorization request: \(error.localizedDescription)",
                     className: String(describing: Swift.type(of: self))
                 )
                 authUrl = buildStandardAuthorizationUrl(request: request)

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/RedirectToWeb/RedirectToWebAuthorizationMethodService.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/RedirectToWeb/RedirectToWebAuthorizationMethodService.swift
@@ -26,15 +26,9 @@ final class RedirectToWebAuthorizationMethodService: AuthorizationMethodService 
         }
 
         let parEndpoint = request.pushedAuthorizationRequestEndpoint
-        let isParRequired = request.requirePushedAuthorizationRequests
 
         let authUrl: String
-        if let parEndpoint, !parEndpoint.isEmpty, isParRequired == true {
-            authUrl = try await buildAuthorizationUrlViaPushedRequest(
-                request: request,
-                parEndpoint: parEndpoint
-            )
-        } else if let parEndpoint, !parEndpoint.isEmpty, isParRequired == nil {
+        if let parEndpoint, !parEndpoint.isEmpty {
             authUrl = try await buildAuthorizationUrlViaPushedRequest(
                 request: request,
                 parEndpoint: parEndpoint

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/RedirectToWeb/RedirectToWebAuthorizationMethodService.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/RedirectToWeb/RedirectToWebAuthorizationMethodService.swift
@@ -51,7 +51,7 @@ final class RedirectToWebAuthorizationMethodService: AuthorizationMethodService 
                     message: "PAR attempt failed at \(parEndpoint) and PAR is not required "
                         + "by the authorization server, falling back to the standard "
                         + "authorization request: \(error.message)",
-                    className: String(describing: type(of: self))
+                    className: String(describing: Swift.type(of: self))
                 )
                 authUrl = buildStandardAuthorizationUrl(request: request)
             }

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/RedirectToWeb/RedirectToWebAuthorizationMethodService.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/RedirectToWeb/RedirectToWebAuthorizationMethodService.swift
@@ -1,9 +1,14 @@
 final class RedirectToWebAuthorizationMethodService: AuthorizationMethodService {
 
     private let openWebPage: OpenWebPageCallback
+    private let parService: PushedAuthorizationRequestService
 
-    init(openWebPage: @escaping OpenWebPageCallback) {
+    init(
+        openWebPage: @escaping OpenWebPageCallback,
+        parService: PushedAuthorizationRequestService = PushedAuthorizationRequestService()
+    ) {
         self.openWebPage = openWebPage
+        self.parService = parService
     }
 
     func type() -> String {
@@ -20,15 +25,35 @@ final class RedirectToWebAuthorizationMethodService: AuthorizationMethodService 
             )
         }
 
-        let authUrl = AuthorizationUrlBuilder.build(
-            baseUrl: request.authorizeUrl,
-            clientId: request.clientMetadata.clientId,
-            redirectUri: request.clientMetadata.redirectUri,
-            scope: request.scope,
-            state: request.pkceSession.state,
-            codeChallenge: request.pkceSession.codeChallenge,
-            nonce: request.pkceSession.nonce
-        )
+        let authUrl: String
+        if let parEndpoint = request.pushedAuthorizationRequestEndpoint, !parEndpoint.isEmpty {
+            let parResponse = try await parService.pushAuthorizationRequest(
+                parEndpoint: parEndpoint,
+                clientId: request.clientMetadata.clientId,
+                redirectUri: request.clientMetadata.redirectUri,
+                codeChallenge: request.pkceSession.codeChallenge,
+                state: request.pkceSession.state,
+                nonce: request.pkceSession.nonce,
+                scope: request.scope,
+                authorizationDetails: request.authorizationDetails,
+                issuerState: request.issuerState
+            )
+            authUrl = AuthorizationUrlBuilder.buildWithRequestUri(
+                baseUrl: request.authorizeUrl,
+                clientId: request.clientMetadata.clientId,
+                requestUri: parResponse.requestUri
+            )
+        } else {
+            authUrl = AuthorizationUrlBuilder.build(
+                baseUrl: request.authorizeUrl,
+                clientId: request.clientMetadata.clientId,
+                redirectUri: request.clientMetadata.redirectUri,
+                scope: request.scope,
+                state: request.pkceSession.state,
+                codeChallenge: request.pkceSession.codeChallenge,
+                nonce: request.pkceSession.nonce
+            )
+        }
 
         let authorizationResponse = try await openWebPage(authUrl)
 

--- a/Sources/VCIClient/authorizationServer/AuthorizationServerMetadata.swift
+++ b/Sources/VCIClient/authorizationServer/AuthorizationServerMetadata.swift
@@ -8,9 +8,7 @@ struct AuthorizationServerMetadata: Codable {
     let interactiveAuthorizationEndpoint: String?
     let requireInteractiveAuthorizationRequest: Bool?
     let pushedAuthorizationRequestEndpoint: String?
-    let requirePushedAuthorizationRequests: Bool?
     let dpopSigningAlgValuesSupported: [String]?
-    let tokenEndpointAuthMethodsSupported: [String]?
 
     enum CodingKeys: String, CodingKey {
         case issuer
@@ -20,9 +18,7 @@ struct AuthorizationServerMetadata: Codable {
         case interactiveAuthorizationEndpoint = "interactive_authorization_endpoint"
         case requireInteractiveAuthorizationRequest = "require_interactive_authorization_request"
         case pushedAuthorizationRequestEndpoint = "pushed_authorization_request_endpoint"
-        case requirePushedAuthorizationRequests = "require_pushed_authorization_requests"
         case dpopSigningAlgValuesSupported = "dpop_signing_alg_values_supported"
-        case tokenEndpointAuthMethodsSupported = "token_endpoint_auth_methods_supported"
     }
 
     init(
@@ -33,9 +29,7 @@ struct AuthorizationServerMetadata: Codable {
         interactiveAuthorizationEndpoint: String?,
         requireInteractiveAuthorizationRequest: Bool? = nil,
         pushedAuthorizationRequestEndpoint: String? = nil,
-        requirePushedAuthorizationRequests: Bool? = nil,
-        dpopSigningAlgValuesSupported: [String]? = nil,
-        tokenEndpointAuthMethodsSupported: [String]? = nil
+        dpopSigningAlgValuesSupported: [String]? = nil
     ) {
         self.issuer = issuer
         self.grantTypesSupported = grantTypesSupported
@@ -44,8 +38,6 @@ struct AuthorizationServerMetadata: Codable {
         self.interactiveAuthorizationEndpoint = interactiveAuthorizationEndpoint
         self.requireInteractiveAuthorizationRequest = requireInteractiveAuthorizationRequest
         self.pushedAuthorizationRequestEndpoint = pushedAuthorizationRequestEndpoint
-        self.requirePushedAuthorizationRequests = requirePushedAuthorizationRequests
         self.dpopSigningAlgValuesSupported = dpopSigningAlgValuesSupported
-        self.tokenEndpointAuthMethodsSupported = tokenEndpointAuthMethodsSupported
     }
 }

--- a/Sources/VCIClient/authorizationServer/AuthorizationServerMetadata.swift
+++ b/Sources/VCIClient/authorizationServer/AuthorizationServerMetadata.swift
@@ -7,6 +7,8 @@ struct AuthorizationServerMetadata: Codable {
     let authorizationEndpoint: String?
     let interactiveAuthorizationEndpoint: String?
     let requireInteractiveAuthorizationRequest: Bool?
+    let pushedAuthorizationRequestEndpoint: String?
+    let requirePushedAuthorizationRequests: Bool?
 
     enum CodingKeys: String, CodingKey {
         case issuer
@@ -15,6 +17,27 @@ struct AuthorizationServerMetadata: Codable {
         case authorizationEndpoint = "authorization_endpoint"
         case interactiveAuthorizationEndpoint = "interactive_authorization_endpoint"
         case requireInteractiveAuthorizationRequest = "require_interactive_authorization_request"
+        case pushedAuthorizationRequestEndpoint = "pushed_authorization_request_endpoint"
+        case requirePushedAuthorizationRequests = "require_pushed_authorization_requests"
+    }
+
+    init(
+        issuer: String,
+        grantTypesSupported: [String]?,
+        tokenEndpoint: String?,
+        authorizationEndpoint: String?,
+        interactiveAuthorizationEndpoint: String?,
+        requireInteractiveAuthorizationRequest: Bool? = nil,
+        pushedAuthorizationRequestEndpoint: String? = nil,
+        requirePushedAuthorizationRequests: Bool? = nil
+    ) {
+        self.issuer = issuer
+        self.grantTypesSupported = grantTypesSupported
+        self.tokenEndpoint = tokenEndpoint
+        self.authorizationEndpoint = authorizationEndpoint
+        self.interactiveAuthorizationEndpoint = interactiveAuthorizationEndpoint
+        self.requireInteractiveAuthorizationRequest = requireInteractiveAuthorizationRequest
+        self.pushedAuthorizationRequestEndpoint = pushedAuthorizationRequestEndpoint
+        self.requirePushedAuthorizationRequests = requirePushedAuthorizationRequests
     }
 }
-

--- a/Sources/VCIClient/authorizationServer/AuthorizationServerMetadata.swift
+++ b/Sources/VCIClient/authorizationServer/AuthorizationServerMetadata.swift
@@ -8,6 +8,7 @@ struct AuthorizationServerMetadata: Codable {
     let interactiveAuthorizationEndpoint: String?
     let requireInteractiveAuthorizationRequest: Bool?
     let pushedAuthorizationRequestEndpoint: String?
+    let requirePushedAuthorizationRequests: Bool?
     let dpopSigningAlgValuesSupported: [String]?
 
     enum CodingKeys: String, CodingKey {
@@ -18,6 +19,7 @@ struct AuthorizationServerMetadata: Codable {
         case interactiveAuthorizationEndpoint = "interactive_authorization_endpoint"
         case requireInteractiveAuthorizationRequest = "require_interactive_authorization_request"
         case pushedAuthorizationRequestEndpoint = "pushed_authorization_request_endpoint"
+        case requirePushedAuthorizationRequests = "require_pushed_authorization_requests"
         case dpopSigningAlgValuesSupported = "dpop_signing_alg_values_supported"
     }
 
@@ -29,6 +31,7 @@ struct AuthorizationServerMetadata: Codable {
         interactiveAuthorizationEndpoint: String?,
         requireInteractiveAuthorizationRequest: Bool? = nil,
         pushedAuthorizationRequestEndpoint: String? = nil,
+        requirePushedAuthorizationRequests: Bool? = nil,
         dpopSigningAlgValuesSupported: [String]? = nil
     ) {
         self.issuer = issuer
@@ -38,6 +41,7 @@ struct AuthorizationServerMetadata: Codable {
         self.interactiveAuthorizationEndpoint = interactiveAuthorizationEndpoint
         self.requireInteractiveAuthorizationRequest = requireInteractiveAuthorizationRequest
         self.pushedAuthorizationRequestEndpoint = pushedAuthorizationRequestEndpoint
+        self.requirePushedAuthorizationRequests = requirePushedAuthorizationRequests
         self.dpopSigningAlgValuesSupported = dpopSigningAlgValuesSupported
     }
 }

--- a/Sources/VCIClient/authorizationServer/AuthorizationServerMetadata.swift
+++ b/Sources/VCIClient/authorizationServer/AuthorizationServerMetadata.swift
@@ -10,6 +10,7 @@ struct AuthorizationServerMetadata: Codable {
     let pushedAuthorizationRequestEndpoint: String?
     let requirePushedAuthorizationRequests: Bool?
     let dpopSigningAlgValuesSupported: [String]?
+    let tokenEndpointAuthMethodsSupported: [String]?
 
     enum CodingKeys: String, CodingKey {
         case issuer
@@ -21,6 +22,7 @@ struct AuthorizationServerMetadata: Codable {
         case pushedAuthorizationRequestEndpoint = "pushed_authorization_request_endpoint"
         case requirePushedAuthorizationRequests = "require_pushed_authorization_requests"
         case dpopSigningAlgValuesSupported = "dpop_signing_alg_values_supported"
+        case tokenEndpointAuthMethodsSupported = "token_endpoint_auth_methods_supported"
     }
 
     init(
@@ -32,7 +34,8 @@ struct AuthorizationServerMetadata: Codable {
         requireInteractiveAuthorizationRequest: Bool? = nil,
         pushedAuthorizationRequestEndpoint: String? = nil,
         requirePushedAuthorizationRequests: Bool? = nil,
-        dpopSigningAlgValuesSupported: [String]? = nil
+        dpopSigningAlgValuesSupported: [String]? = nil,
+        tokenEndpointAuthMethodsSupported: [String]? = nil
     ) {
         self.issuer = issuer
         self.grantTypesSupported = grantTypesSupported
@@ -43,5 +46,6 @@ struct AuthorizationServerMetadata: Codable {
         self.pushedAuthorizationRequestEndpoint = pushedAuthorizationRequestEndpoint
         self.requirePushedAuthorizationRequests = requirePushedAuthorizationRequests
         self.dpopSigningAlgValuesSupported = dpopSigningAlgValuesSupported
+        self.tokenEndpointAuthMethodsSupported = tokenEndpointAuthMethodsSupported
     }
 }

--- a/Sources/VCIClient/authorizationServer/AuthorizationUrlBuilder.swift
+++ b/Sources/VCIClient/authorizationServer/AuthorizationUrlBuilder.swift
@@ -2,7 +2,7 @@ import Foundation
 
 enum AuthorizationUrlBuilder {
     
-    static func build(
+    static func buildWithParameters(
         baseUrl: String,
         clientId: String,
         redirectUri: String,

--- a/Sources/VCIClient/authorizationServer/AuthorizationUrlBuilder.swift
+++ b/Sources/VCIClient/authorizationServer/AuthorizationUrlBuilder.swift
@@ -25,6 +25,17 @@ enum AuthorizationUrlBuilder {
         return url
     }
 
+    static func buildWithRequestUri(
+        baseUrl: String,
+        clientId: String,
+        requestUri: String
+    ) -> String {
+        var url = baseUrl
+        url += "?client_id=\(encode(clientId))"
+        url += "&request_uri=\(encode(requestUri))"
+        return url
+    }
+
     private static func encode(_ value: String) -> String {
         return value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? value
     }

--- a/Sources/VCIClient/authorizationServer/PushedAuthorizationRequestService.swift
+++ b/Sources/VCIClient/authorizationServer/PushedAuthorizationRequestService.swift
@@ -10,6 +10,7 @@ class PushedAuthorizationRequestService {
         state: String,
         nonce: String,
         scope: String? = nil,
+        dpopJkt: String? = nil,
         codeChallengeMethod: CodeChallengeMethod = .s256,
         responseType: AuthorizationResponseType = .code,
         clientAuthParams: [String: String] = [:],
@@ -28,6 +29,10 @@ class PushedAuthorizationRequestService {
 
         if let scope = scope, !scope.isEmpty {
             params["scope"] = scope
+        }
+
+        if let dpopJkt = dpopJkt, !dpopJkt.isEmpty {
+            params["dpop_jkt"] = dpopJkt
         }
 
         // Core authorization request params take precedence; clientAuthParams

--- a/Sources/VCIClient/authorizationServer/PushedAuthorizationRequestService.swift
+++ b/Sources/VCIClient/authorizationServer/PushedAuthorizationRequestService.swift
@@ -10,8 +10,6 @@ class PushedAuthorizationRequestService {
         state: String,
         nonce: String,
         scope: String? = nil,
-        authorizationDetails: String? = nil,
-        issuerState: String? = nil,
         codeChallengeMethod: CodeChallengeMethod = .s256,
         responseType: AuthorizationResponseType = .code,
         clientAuthParams: [String: String] = [:],
@@ -28,18 +26,8 @@ class PushedAuthorizationRequestService {
             "nonce": nonce,
         ]
 
-        if let authorizationDetails = authorizationDetails, !authorizationDetails.isEmpty {
-            params["authorization_details"] = authorizationDetails
-        } else if let scope = scope, !scope.isEmpty {
+        if let scope = scope, !scope.isEmpty {
             params["scope"] = scope
-        } else {
-            throw PushedAuthorizationRequestException(
-                "Either scope or authorization_details must be provided for a PAR request"
-            )
-        }
-
-        if let issuerState = issuerState, !issuerState.isEmpty {
-            params["issuer_state"] = issuerState
         }
 
         // Core authorization request params take precedence; clientAuthParams

--- a/Sources/VCIClient/authorizationServer/PushedAuthorizationRequestService.swift
+++ b/Sources/VCIClient/authorizationServer/PushedAuthorizationRequestService.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+class PushedAuthorizationRequestService {
+
+    func pushAuthorizationRequest(
+        parEndpoint: String,
+        clientId: String,
+        redirectUri: String,
+        codeChallenge: String,
+        state: String,
+        nonce: String,
+        scope: String? = nil,
+        authorizationDetails: String? = nil,
+        issuerState: String? = nil,
+        codeChallengeMethod: CodeChallengeMethod = .s256,
+        responseType: AuthorizationResponseType = .code,
+        clientAuthParams: [String: String] = [:],
+        timeoutMillis: Int64 = Constants.defaultNetworkTimeoutInMillis,
+        session: NetworkManager = NetworkManager.shared
+    ) async throws -> PushedAuthorizationResponse {
+        var params: [String: String] = [
+            "response_type": responseType.rawValue,
+            "client_id": clientId,
+            "redirect_uri": redirectUri,
+            "code_challenge": codeChallenge,
+            "code_challenge_method": codeChallengeMethod.rawValue,
+            "state": state,
+            "nonce": nonce,
+        ]
+
+        if let authorizationDetails = authorizationDetails, !authorizationDetails.isEmpty {
+            params["authorization_details"] = authorizationDetails
+        } else if let scope = scope, !scope.isEmpty {
+            params["scope"] = scope
+        }
+
+        if let issuerState = issuerState, !issuerState.isEmpty {
+            params["issuer_state"] = issuerState
+        }
+
+        params.merge(clientAuthParams) { _, new in new }
+
+        let response: NetworkResponse
+        do {
+            response = try await session.sendRequest(
+                url: parEndpoint,
+                method: .post,
+                headers: [Header.contentType.rawValue: ContentTypes.applicationFormUrlEncoded.rawValue],
+                bodyParams: params,
+                timeoutMillis: timeoutMillis
+            )
+        } catch let e as VCIClientException {
+            throw PushedAuthorizationRequestException(
+                message: "PAR request failed at \(parEndpoint): \(e.message)",
+                issuerErrorCode: e.issuerErrorCode,
+                issuerErrorDescription: e.issuerErrorDescription,
+                cause: e
+            )
+        } catch {
+            throw PushedAuthorizationRequestException(
+                message: "PAR request failed at \(parEndpoint): \(error.localizedDescription)",
+                cause: error
+            )
+        }
+
+        let parResponse: PushedAuthorizationResponse?
+        do {
+            parResponse = try JsonUtils.deserialize(
+                response.body,
+                as: PushedAuthorizationResponse.self
+            )
+        } catch {
+            throw PushedAuthorizationRequestException(
+                message: "Invalid PAR response from \(parEndpoint): \(error.localizedDescription)",
+                cause: error
+            )
+        }
+
+        guard let parResponse = parResponse, !parResponse.requestUri.isEmpty else {
+            throw PushedAuthorizationRequestException(
+                "Invalid PAR response from \(parEndpoint): missing request_uri"
+            )
+        }
+
+        return parResponse
+    }
+}

--- a/Sources/VCIClient/authorizationServer/PushedAuthorizationRequestService.swift
+++ b/Sources/VCIClient/authorizationServer/PushedAuthorizationRequestService.swift
@@ -32,6 +32,10 @@ class PushedAuthorizationRequestService {
             params["authorization_details"] = authorizationDetails
         } else if let scope = scope, !scope.isEmpty {
             params["scope"] = scope
+        } else {
+            throw PushedAuthorizationRequestException(
+                "Either scope or authorization_details must be provided for a PAR request"
+            )
         }
 
         if let issuerState = issuerState, !issuerState.isEmpty {

--- a/Sources/VCIClient/authorizationServer/PushedAuthorizationRequestService.swift
+++ b/Sources/VCIClient/authorizationServer/PushedAuthorizationRequestService.swift
@@ -38,7 +38,9 @@ class PushedAuthorizationRequestService {
             params["issuer_state"] = issuerState
         }
 
-        params.merge(clientAuthParams) { _, new in new }
+        // Core authorization request params take precedence; clientAuthParams
+        // (e.g. client_assertion) may only add keys, never override reserved fields.
+        params.merge(clientAuthParams) { current, _ in current }
 
         let response: NetworkResponse
         do {

--- a/Sources/VCIClient/authorizationServer/PushedAuthorizationResponse.swift
+++ b/Sources/VCIClient/authorizationServer/PushedAuthorizationResponse.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+struct PushedAuthorizationResponse: Codable {
+    let requestUri: String
+    let expiresIn: Int64?
+
+    enum CodingKeys: String, CodingKey {
+        case requestUri = "request_uri"
+        case expiresIn = "expires_in"
+    }
+}

--- a/Sources/VCIClient/exceptions/PushedAuthorizationRequestException.swift
+++ b/Sources/VCIClient/exceptions/PushedAuthorizationRequestException.swift
@@ -3,7 +3,7 @@ import Foundation
 class PushedAuthorizationRequestException: VCIClientException {
     init(_ message: String?) {
         super.init(
-            code: "VCI-013",
+            code: "VCI-014",
             message: "Pushed authorization request failed: \(message ?? "")"
         )
     }
@@ -15,7 +15,7 @@ class PushedAuthorizationRequestException: VCIClientException {
         cause: Error? = nil
     ) {
         super.init(
-            code: "VCI-013",
+            code: "VCI-014",
             message: "Pushed authorization request failed: \(message ?? "")",
             issuerErrorCode: issuerErrorCode,
             issuerErrorDescription: issuerErrorDescription,

--- a/Sources/VCIClient/exceptions/PushedAuthorizationRequestException.swift
+++ b/Sources/VCIClient/exceptions/PushedAuthorizationRequestException.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+class PushedAuthorizationRequestException: VCIClientException {
+    init(_ message: String?) {
+        super.init(
+            code: "VCI-PAR",
+            message: "Pushed authorization request failed: \(message ?? "")"
+        )
+    }
+
+    init(
+        message: String?,
+        issuerErrorCode: String? = nil,
+        issuerErrorDescription: String? = nil,
+        cause: Error? = nil
+    ) {
+        super.init(
+            code: "VCI-PAR",
+            message: "Pushed authorization request failed: \(message ?? "")",
+            issuerErrorCode: issuerErrorCode,
+            issuerErrorDescription: issuerErrorDescription,
+            cause: cause
+        )
+    }
+}

--- a/Sources/VCIClient/exceptions/PushedAuthorizationRequestException.swift
+++ b/Sources/VCIClient/exceptions/PushedAuthorizationRequestException.swift
@@ -3,7 +3,7 @@ import Foundation
 class PushedAuthorizationRequestException: VCIClientException {
     init(_ message: String?) {
         super.init(
-            code: "VCI-PAR",
+            code: "VCI-012",
             message: "Pushed authorization request failed: \(message ?? "")"
         )
     }
@@ -15,7 +15,7 @@ class PushedAuthorizationRequestException: VCIClientException {
         cause: Error? = nil
     ) {
         super.init(
-            code: "VCI-PAR",
+            code: "VCI-012",
             message: "Pushed authorization request failed: \(message ?? "")",
             issuerErrorCode: issuerErrorCode,
             issuerErrorDescription: issuerErrorDescription,

--- a/Sources/VCIClient/exceptions/PushedAuthorizationRequestException.swift
+++ b/Sources/VCIClient/exceptions/PushedAuthorizationRequestException.swift
@@ -3,7 +3,7 @@ import Foundation
 class PushedAuthorizationRequestException: VCIClientException {
     init(_ message: String?) {
         super.init(
-            code: "VCI-012",
+            code: "VCI-013",
             message: "Pushed authorization request failed: \(message ?? "")"
         )
     }
@@ -15,7 +15,7 @@ class PushedAuthorizationRequestException: VCIClientException {
         cause: Error? = nil
     ) {
         super.init(
-            code: "VCI-012",
+            code: "VCI-013",
             message: "Pushed authorization request failed: \(message ?? "")",
             issuerErrorCode: issuerErrorCode,
             issuerErrorDescription: issuerErrorDescription,

--- a/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/RedirectToWeb/RedirectToWebAuthorizationMethodServiceTests.swift
+++ b/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/RedirectToWeb/RedirectToWebAuthorizationMethodServiceTests.swift
@@ -13,7 +13,9 @@ final class RedirectToWebAuthorizationMethodServiceTests: XCTestCase {
         codeVerifier: String = "verifier-abc",
         codeChallenge: String = "challenge-xyz",
         state: String = "state-123",
-        nonce: String = "nonce-456"
+        nonce: String = "nonce-456",
+        pushedAuthorizationRequestEndpoint: String? = nil,
+        requirePushedAuthorizationRequests: Bool? = nil
     ) -> ImplicitAuthorizationRequestData {
         let clientMetadata = ClientMetadata(clientId: clientId, redirectUri: redirectUri)
         let pkceSession = PKCESessionManager.PKCESession(
@@ -27,6 +29,8 @@ final class RedirectToWebAuthorizationMethodServiceTests: XCTestCase {
             clientMetadata: clientMetadata,
             pkceSession: pkceSession,
             scope: scope,
+            pushedAuthorizationRequestEndpoint: pushedAuthorizationRequestEndpoint,
+            requirePushedAuthorizationRequests: requirePushedAuthorizationRequests,
             dpopJkt: "test-jkt"
         )
     }
@@ -158,7 +162,196 @@ final class RedirectToWebAuthorizationMethodServiceTests: XCTestCase {
         }
         XCTAssertEqual(query["nonce"], nonce)
     }
+
+    func test_authorizeUser_whenParIsMandatory_usesPushedRequest() async throws {
+        let parService = StubPARService(
+            result: .success(
+                PushedAuthorizationResponse(requestUri: "urn:req:abc", expiresIn: 90)
+            )
+        )
+        var capturedUrl: String?
+        let service = RedirectToWebAuthorizationMethodService(
+            openWebPage: { url in
+                capturedUrl = url
+                return ["code": "authcode123"]
+            },
+            parService: parService
+        )
+
+        let response = try await service.authorizeUser(
+            requestData: makeValidRequestData(
+                pushedAuthorizationRequestEndpoint: "https://as.example.com/as/par",
+                requirePushedAuthorizationRequests: true
+            )
+        )
+
+        XCTAssertEqual(response.status, "success")
+        XCTAssertEqual(parService.callCount, 1)
+        XCTAssertTrue(capturedUrl?.contains("request_uri=urn:req:abc") ?? false)
+    }
+
+    func test_authorizeUser_whenParIsMandatoryAndParFails_throwsWithoutFallback() async {
+        let parService = StubPARService(
+            result: .failure(PushedAuthorizationRequestException(message: "HTTP 400"))
+        )
+        var callbackInvoked = false
+        let service = RedirectToWebAuthorizationMethodService(
+            openWebPage: { _ in
+                callbackInvoked = true
+                return ["code": "authcode123"]
+            },
+            parService: parService
+        )
+
+        do {
+            _ = try await service.authorizeUser(
+                requestData: makeValidRequestData(
+                    pushedAuthorizationRequestEndpoint: "https://as.example.com/as/par",
+                    requirePushedAuthorizationRequests: true
+                )
+            )
+            XCTFail("Expected PushedAuthorizationRequestException to be thrown")
+        } catch is PushedAuthorizationRequestException {
+            XCTAssertFalse(callbackInvoked, "Must not fall back when PAR is mandatory")
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func test_authorizeUser_whenParIsMandatoryButNoEndpointAdvertised_throws() async {
+        let parService = StubPARService(
+            result: .success(
+                PushedAuthorizationResponse(requestUri: "urn:req:abc", expiresIn: 90)
+            )
+        )
+        var callbackInvoked = false
+        let service = RedirectToWebAuthorizationMethodService(
+            openWebPage: { _ in
+                callbackInvoked = true
+                return ["code": "authcode123"]
+            },
+            parService: parService
+        )
+
+        do {
+            _ = try await service.authorizeUser(
+                requestData: makeValidRequestData(requirePushedAuthorizationRequests: true)
+            )
+            XCTFail("Expected PushedAuthorizationRequestException to be thrown")
+        } catch is PushedAuthorizationRequestException {
+            XCTAssertEqual(parService.callCount, 0)
+            XCTAssertFalse(callbackInvoked)
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func test_authorizeUser_whenParIsOptionalAndParFails_fallsBackToStandardRequest() async throws {
+        let parService = StubPARService(
+            result: .failure(PushedAuthorizationRequestException(message: "HTTP 400"))
+        )
+        var capturedUrl: String?
+        let service = RedirectToWebAuthorizationMethodService(
+            openWebPage: { url in
+                capturedUrl = url
+                return ["code": "authcode123"]
+            },
+            parService: parService
+        )
+
+        let response = try await service.authorizeUser(
+            requestData: makeValidRequestData(
+                pushedAuthorizationRequestEndpoint: "https://as.example.com/as/par",
+                requirePushedAuthorizationRequests: false
+            )
+        )
+
+        XCTAssertEqual(response.status, "success")
+        XCTAssertEqual(parService.callCount, 1)
+        XCTAssertFalse(capturedUrl?.contains("request_uri") ?? true)
+        XCTAssertTrue(capturedUrl?.contains("code_challenge=challenge-xyz") ?? false)
+    }
+
+    func test_authorizeUser_whenParFlagOmittedAndParFails_fallsBackToStandardRequest() async throws {
+        let parService = StubPARService(
+            result: .failure(PushedAuthorizationRequestException(message: "timeout"))
+        )
+        var capturedUrl: String?
+        let service = RedirectToWebAuthorizationMethodService(
+            openWebPage: { url in
+                capturedUrl = url
+                return ["code": "authcode123"]
+            },
+            parService: parService
+        )
+
+        let response = try await service.authorizeUser(
+            requestData: makeValidRequestData(
+                pushedAuthorizationRequestEndpoint: "https://as.example.com/as/par"
+            )
+        )
+
+        XCTAssertEqual(response.status, "success")
+        XCTAssertEqual(parService.callCount, 1)
+        XCTAssertFalse(capturedUrl?.contains("request_uri") ?? true)
+    }
+
+    func test_authorizeUser_whenParFlagOmittedAndNoEndpoint_usesStandardRequestWithoutPar() async throws {
+        let parService = StubPARService(
+            result: .success(
+                PushedAuthorizationResponse(requestUri: "urn:req:abc", expiresIn: 90)
+            )
+        )
+        var capturedUrl: String?
+        let service = RedirectToWebAuthorizationMethodService(
+            openWebPage: { url in
+                capturedUrl = url
+                return ["code": "authcode123"]
+            },
+            parService: parService
+        )
+
+        let response = try await service.authorizeUser(requestData: makeValidRequestData())
+
+        XCTAssertEqual(response.status, "success")
+        XCTAssertEqual(parService.callCount, 0)
+        XCTAssertFalse(capturedUrl?.contains("request_uri") ?? true)
+    }
 }
 
 // Dummy class to simulate invalid request data
 private final class DummyAuthorizationRequestData: AuthorizationRequestData {}
+
+private final class StubPARService: PushedAuthorizationRequestService {
+    private let result: Result<PushedAuthorizationResponse, Error>
+    private(set) var callCount = 0
+
+    init(result: Result<PushedAuthorizationResponse, Error>) {
+        self.result = result
+        super.init()
+    }
+
+    override func pushAuthorizationRequest(
+        parEndpoint: String,
+        clientId: String,
+        redirectUri: String,
+        codeChallenge: String,
+        state: String,
+        nonce: String,
+        scope: String? = nil,
+        dpopJkt: String? = nil,
+        codeChallengeMethod: CodeChallengeMethod = .s256,
+        responseType: AuthorizationResponseType = .code,
+        clientAuthParams: [String: String] = [:],
+        timeoutMillis: Int64 = Constants.defaultNetworkTimeoutInMillis,
+        session: NetworkManager = NetworkManager.shared
+    ) async throws -> PushedAuthorizationResponse {
+        callCount += 1
+        switch result {
+        case .success(let response):
+            return response
+        case .failure(let error):
+            throw error
+        }
+    }
+}

--- a/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/RedirectToWeb/RedirectToWebAuthorizationMethodServiceTests.swift
+++ b/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/RedirectToWeb/RedirectToWebAuthorizationMethodServiceTests.swift
@@ -296,6 +296,104 @@ final class RedirectToWebAuthorizationMethodServiceTests: XCTestCase {
         XCTAssertFalse(capturedUrl?.contains("request_uri") ?? true)
     }
 
+    func test_authorizeUser_whenParIsExplicitlyOptionalAndParSucceeds_usesPushedRequest() async throws {
+        let parService = StubPARService(
+            result: .success(
+                PushedAuthorizationResponse(requestUri: "urn:req:abc", expiresIn: 90)
+            )
+        )
+        var capturedUrl: String?
+        let service = RedirectToWebAuthorizationMethodService(
+            openWebPage: { url in
+                capturedUrl = url
+                return ["code": "authcode123"]
+            },
+            parService: parService
+        )
+
+        let response = try await service.authorizeUser(
+            requestData: makeValidRequestData(
+                pushedAuthorizationRequestEndpoint: "https://as.example.com/as/par",
+                requirePushedAuthorizationRequests: false
+            )
+        )
+
+        XCTAssertEqual(response.status, "success")
+        XCTAssertEqual(parService.callCount, 1)
+        XCTAssertTrue(capturedUrl?.contains("request_uri=urn:req:abc") ?? false)
+    }
+
+    func test_authorizeUser_whenParIsExplicitlyOptionalAndNoEndpoint_usesStandardRequest() async throws {
+        let parService = StubPARService(
+            result: .success(
+                PushedAuthorizationResponse(requestUri: "urn:req:abc", expiresIn: 90)
+            )
+        )
+        var capturedUrl: String?
+        let service = RedirectToWebAuthorizationMethodService(
+            openWebPage: { url in
+                capturedUrl = url
+                return ["code": "authcode123"]
+            },
+            parService: parService
+        )
+
+        let response = try await service.authorizeUser(
+            requestData: makeValidRequestData(requirePushedAuthorizationRequests: false)
+        )
+
+        XCTAssertEqual(response.status, "success")
+        XCTAssertEqual(parService.callCount, 0)
+        XCTAssertFalse(capturedUrl?.contains("request_uri") ?? true)
+    }
+
+    func test_authorizeUser_whenOptionalParFailsWithOtherError_fallsBackToStandardRequest() async throws {
+        let parService = StubPARService(result: .failure(StubPARError.unexpected))
+        var capturedUrl: String?
+        let service = RedirectToWebAuthorizationMethodService(
+            openWebPage: { url in
+                capturedUrl = url
+                return ["code": "authcode123"]
+            },
+            parService: parService
+        )
+
+        let response = try await service.authorizeUser(
+            requestData: makeValidRequestData(
+                pushedAuthorizationRequestEndpoint: "https://as.example.com/as/par",
+                requirePushedAuthorizationRequests: false
+            )
+        )
+
+        XCTAssertEqual(response.status, "success")
+        XCTAssertEqual(parService.callCount, 1)
+        XCTAssertFalse(capturedUrl?.contains("request_uri") ?? true)
+    }
+
+    func test_authorizeUser_whenMandatoryParFailsWithOtherError_throwsWithoutFallback() async {
+        let parService = StubPARService(result: .failure(StubPARError.unexpected))
+        var callbackInvoked = false
+        let service = RedirectToWebAuthorizationMethodService(
+            openWebPage: { _ in
+                callbackInvoked = true
+                return ["code": "authcode123"]
+            },
+            parService: parService
+        )
+
+        do {
+            _ = try await service.authorizeUser(
+                requestData: makeValidRequestData(
+                    pushedAuthorizationRequestEndpoint: "https://as.example.com/as/par",
+                    requirePushedAuthorizationRequests: true
+                )
+            )
+            XCTFail("Expected the PAR failure to propagate")
+        } catch {
+            XCTAssertFalse(callbackInvoked, "Must not fall back when PAR is mandatory")
+        }
+    }
+
     func test_authorizeUser_whenParFlagOmittedAndNoEndpoint_usesStandardRequestWithoutPar() async throws {
         let parService = StubPARService(
             result: .success(
@@ -321,6 +419,10 @@ final class RedirectToWebAuthorizationMethodServiceTests: XCTestCase {
 
 // Dummy class to simulate invalid request data
 private final class DummyAuthorizationRequestData: AuthorizationRequestData {}
+
+private enum StubPARError: Error {
+    case unexpected
+}
 
 private final class StubPARService: PushedAuthorizationRequestService {
     private let result: Result<PushedAuthorizationResponse, Error>

--- a/Tests/VCIClientTests/authorizationServer/AuthorizationServerMetadataTests.swift
+++ b/Tests/VCIClientTests/authorizationServer/AuthorizationServerMetadataTests.swift
@@ -1,0 +1,43 @@
+@testable import VCIClient
+import XCTest
+
+final class AuthorizationServerMetadataTests: XCTestCase {
+
+    func test_decodesRequireParFlagWhenAdvertisedAsTrue() throws {
+        let json = """
+        {"issuer":"https://as.example","require_pushed_authorization_requests":true}
+        """
+
+        let metadata = try JsonUtils.deserialize(json, as: AuthorizationServerMetadata.self)
+
+        XCTAssertEqual(metadata?.requirePushedAuthorizationRequests, true)
+    }
+
+    func test_decodesRequireParFlagWhenAdvertisedAsFalse() throws {
+        let json = """
+        {"issuer":"https://as.example","require_pushed_authorization_requests":false}
+        """
+
+        let metadata = try JsonUtils.deserialize(json, as: AuthorizationServerMetadata.self)
+
+        XCTAssertEqual(metadata?.requirePushedAuthorizationRequests, false)
+    }
+
+    func test_leavesRequireParFlagNilWhenOmitted() throws {
+        let json = """
+        {
+          "issuer":"https://as.example",
+          "pushed_authorization_request_endpoint":"https://as.example/as/par"
+        }
+        """
+
+        let metadata = try JsonUtils.deserialize(json, as: AuthorizationServerMetadata.self)
+
+        XCTAssertNil(metadata?.requirePushedAuthorizationRequests)
+        XCTAssertEqual(
+            metadata?.pushedAuthorizationRequestEndpoint,
+            "https://as.example/as/par"
+        )
+        XCTAssertEqual(metadata?.requirePushedAuthorizationRequests ?? false, false)
+    }
+}

--- a/Tests/VCIClientTests/authorizationServer/PushedAuthorizationRequestServiceTests.swift
+++ b/Tests/VCIClientTests/authorizationServer/PushedAuthorizationRequestServiceTests.swift
@@ -55,27 +55,7 @@ final class PushedAuthorizationRequestServiceTests: XCTestCase {
         XCTAssertEqual(body["nonce"], "nonce-123")
     }
 
-    func test_sendsAuthorizationDetailsAndOmitsScope() async throws {
-        let mock = makeMock(responseBody: validResponseBody)
-
-        _ = try await PushedAuthorizationRequestService().pushAuthorizationRequest(
-            parEndpoint: parEndpoint,
-            clientId: "client-id",
-            redirectUri: "app://callback",
-            codeChallenge: "challenge",
-            state: "state-123",
-            nonce: "nonce-123",
-            scope: "openid",
-            authorizationDetails: "[{\"type\":\"openid_credential\"}]",
-            session: mock
-        )
-
-        let body = mock.capturedParams
-        XCTAssertEqual(body["authorization_details"], "[{\"type\":\"openid_credential\"}]")
-        XCTAssertNil(body["scope"])
-    }
-
-    func test_sendsScopeWhenAuthorizationDetailsAbsent() async throws {
+    func test_sendsScopeAndNeverAuthorizationDetails() async throws {
         let mock = makeMock(responseBody: validResponseBody)
 
         _ = try await PushedAuthorizationRequestService().pushAuthorizationRequest(
@@ -92,35 +72,6 @@ final class PushedAuthorizationRequestServiceTests: XCTestCase {
         let body = mock.capturedParams
         XCTAssertEqual(body["scope"], "openid")
         XCTAssertNil(body["authorization_details"])
-    }
-
-    func test_includesIssuerStateOnlyWhenPresent() async throws {
-        let withMock = makeMock(responseBody: validResponseBody)
-        _ = try await PushedAuthorizationRequestService().pushAuthorizationRequest(
-            parEndpoint: parEndpoint,
-            clientId: "client-id",
-            redirectUri: "app://callback",
-            codeChallenge: "challenge",
-            state: "state-123",
-            nonce: "nonce-123",
-            scope: "openid",
-            issuerState: "issuer-state-xyz",
-            session: withMock
-        )
-        XCTAssertEqual(withMock.capturedParams["issuer_state"], "issuer-state-xyz")
-
-        let withoutMock = makeMock(responseBody: validResponseBody)
-        _ = try await PushedAuthorizationRequestService().pushAuthorizationRequest(
-            parEndpoint: parEndpoint,
-            clientId: "client-id",
-            redirectUri: "app://callback",
-            codeChallenge: "challenge",
-            state: "state-123",
-            nonce: "nonce-123",
-            scope: "openid",
-            session: withoutMock
-        )
-        XCTAssertNil(withoutMock.capturedParams["issuer_state"])
     }
 
     func test_mergesClientAuthParamsIntoBody() async throws {
@@ -165,27 +116,6 @@ final class PushedAuthorizationRequestServiceTests: XCTestCase {
         )
 
         XCTAssertEqual(mock.capturedParams["client_id"], "real-client-id")
-    }
-
-    func test_throwsWhenBothScopeAndAuthorizationDetailsAbsent() async {
-        let mock = makeMock(responseBody: validResponseBody)
-
-        do {
-            _ = try await PushedAuthorizationRequestService().pushAuthorizationRequest(
-                parEndpoint: parEndpoint,
-                clientId: "client-id",
-                redirectUri: "app://callback",
-                codeChallenge: "challenge",
-                state: "state-123",
-                nonce: "nonce-123",
-                session: mock
-            )
-            XCTFail("Expected PushedAuthorizationRequestException to be thrown")
-        } catch is PushedAuthorizationRequestException {
-            // expected
-        } catch {
-            XCTFail("Unexpected error type: \(error)")
-        }
     }
 
     func test_throwsWhenResponseHasNoRequestUri() async {

--- a/Tests/VCIClientTests/authorizationServer/PushedAuthorizationRequestServiceTests.swift
+++ b/Tests/VCIClientTests/authorizationServer/PushedAuthorizationRequestServiceTests.swift
@@ -1,0 +1,213 @@
+@testable import VCIClient
+import XCTest
+
+final class PushedAuthorizationRequestServiceTests: XCTestCase {
+
+    private let parEndpoint = "https://as.example.com/as/par"
+    private let validResponseBody =
+        "{\"request_uri\":\"urn:ietf:params:oauth:request_uri:abc\",\"expires_in\":90}"
+
+    private func makeMock(responseBody: String) -> MockNetworkManager {
+        let mock = MockNetworkManager()
+        mock.responseBody = responseBody
+        return mock
+    }
+
+    func test_success_returnsRequestUriAndExpiresIn() async throws {
+        let mock = makeMock(responseBody: validResponseBody)
+
+        let result = try await PushedAuthorizationRequestService().pushAuthorizationRequest(
+            parEndpoint: parEndpoint,
+            clientId: "client-id",
+            redirectUri: "app://callback",
+            codeChallenge: "challenge",
+            state: "state-123",
+            nonce: "nonce-123",
+            scope: "openid",
+            session: mock
+        )
+
+        XCTAssertEqual(result.requestUri, "urn:ietf:params:oauth:request_uri:abc")
+        XCTAssertEqual(result.expiresIn, 90)
+    }
+
+    func test_alwaysIncludesCoreParamsIncludingNonce() async throws {
+        let mock = makeMock(responseBody: validResponseBody)
+
+        _ = try await PushedAuthorizationRequestService().pushAuthorizationRequest(
+            parEndpoint: parEndpoint,
+            clientId: "client-id",
+            redirectUri: "app://callback",
+            codeChallenge: "challenge",
+            state: "state-123",
+            nonce: "nonce-123",
+            scope: "openid",
+            session: mock
+        )
+
+        let body = mock.capturedParams
+        XCTAssertEqual(body["response_type"], "code")
+        XCTAssertEqual(body["client_id"], "client-id")
+        XCTAssertEqual(body["redirect_uri"], "app://callback")
+        XCTAssertEqual(body["code_challenge"], "challenge")
+        XCTAssertEqual(body["code_challenge_method"], "S256")
+        XCTAssertEqual(body["state"], "state-123")
+        XCTAssertEqual(body["nonce"], "nonce-123")
+    }
+
+    func test_sendsAuthorizationDetailsAndOmitsScope() async throws {
+        let mock = makeMock(responseBody: validResponseBody)
+
+        _ = try await PushedAuthorizationRequestService().pushAuthorizationRequest(
+            parEndpoint: parEndpoint,
+            clientId: "client-id",
+            redirectUri: "app://callback",
+            codeChallenge: "challenge",
+            state: "state-123",
+            nonce: "nonce-123",
+            scope: "openid",
+            authorizationDetails: "[{\"type\":\"openid_credential\"}]",
+            session: mock
+        )
+
+        let body = mock.capturedParams
+        XCTAssertEqual(body["authorization_details"], "[{\"type\":\"openid_credential\"}]")
+        XCTAssertNil(body["scope"])
+    }
+
+    func test_sendsScopeWhenAuthorizationDetailsAbsent() async throws {
+        let mock = makeMock(responseBody: validResponseBody)
+
+        _ = try await PushedAuthorizationRequestService().pushAuthorizationRequest(
+            parEndpoint: parEndpoint,
+            clientId: "client-id",
+            redirectUri: "app://callback",
+            codeChallenge: "challenge",
+            state: "state-123",
+            nonce: "nonce-123",
+            scope: "openid",
+            session: mock
+        )
+
+        let body = mock.capturedParams
+        XCTAssertEqual(body["scope"], "openid")
+        XCTAssertNil(body["authorization_details"])
+    }
+
+    func test_includesIssuerStateOnlyWhenPresent() async throws {
+        let withMock = makeMock(responseBody: validResponseBody)
+        _ = try await PushedAuthorizationRequestService().pushAuthorizationRequest(
+            parEndpoint: parEndpoint,
+            clientId: "client-id",
+            redirectUri: "app://callback",
+            codeChallenge: "challenge",
+            state: "state-123",
+            nonce: "nonce-123",
+            scope: "openid",
+            issuerState: "issuer-state-xyz",
+            session: withMock
+        )
+        XCTAssertEqual(withMock.capturedParams["issuer_state"], "issuer-state-xyz")
+
+        let withoutMock = makeMock(responseBody: validResponseBody)
+        _ = try await PushedAuthorizationRequestService().pushAuthorizationRequest(
+            parEndpoint: parEndpoint,
+            clientId: "client-id",
+            redirectUri: "app://callback",
+            codeChallenge: "challenge",
+            state: "state-123",
+            nonce: "nonce-123",
+            scope: "openid",
+            session: withoutMock
+        )
+        XCTAssertNil(withoutMock.capturedParams["issuer_state"])
+    }
+
+    func test_mergesClientAuthParamsIntoBody() async throws {
+        let mock = makeMock(responseBody: validResponseBody)
+
+        _ = try await PushedAuthorizationRequestService().pushAuthorizationRequest(
+            parEndpoint: parEndpoint,
+            clientId: "client-id",
+            redirectUri: "app://callback",
+            codeChallenge: "challenge",
+            state: "state-123",
+            nonce: "nonce-123",
+            scope: "openid",
+            clientAuthParams: [
+                "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+                "client_assertion": "signed.jwt.value",
+            ],
+            session: mock
+        )
+
+        let body = mock.capturedParams
+        XCTAssertEqual(
+            body["client_assertion_type"],
+            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+        )
+        XCTAssertEqual(body["client_assertion"], "signed.jwt.value")
+    }
+
+    func test_throwsWhenResponseHasNoRequestUri() async {
+        let mock = makeMock(responseBody: "{}")
+
+        do {
+            _ = try await PushedAuthorizationRequestService().pushAuthorizationRequest(
+                parEndpoint: parEndpoint,
+                clientId: "client-id",
+                redirectUri: "app://callback",
+                codeChallenge: "challenge",
+                state: "state-123",
+                nonce: "nonce-123",
+                scope: "openid",
+                session: mock
+            )
+            XCTFail("Expected PushedAuthorizationRequestException to be thrown")
+        } catch is PushedAuthorizationRequestException {
+            // expected
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func test_wrapsServerErrorAndPropagatesIssuerErrorCode() async {
+        let mock = ThrowingPARNetworkManager()
+
+        do {
+            _ = try await PushedAuthorizationRequestService().pushAuthorizationRequest(
+                parEndpoint: parEndpoint,
+                clientId: "client-id",
+                redirectUri: "app://callback",
+                codeChallenge: "challenge",
+                state: "state-123",
+                nonce: "nonce-123",
+                scope: "openid",
+                session: mock
+            )
+            XCTFail("Expected PushedAuthorizationRequestException to be thrown")
+        } catch let ex as PushedAuthorizationRequestException {
+            XCTAssertEqual(ex.issuerErrorCode, "invalid_client")
+            XCTAssertEqual(ex.issuerErrorDescription, "Client authentication failed")
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+}
+
+// Mock that simulates a non-2xx PAR response surfaced as NetworkRequestFailedException.
+private final class ThrowingPARNetworkManager: NetworkManager {
+    override func sendRequest(
+        url: String,
+        method: HttpMethod,
+        headers: [String: String]?,
+        bodyParams: [String: String]?,
+        timeoutMillis: Int64
+    ) async throws -> NetworkResponse {
+        throw NetworkRequestFailedException(
+            message: "HTTP 401",
+            issuerErrorCode: "invalid_client",
+            issuerErrorDescription: "Client authentication failed"
+        )
+    }
+}

--- a/Tests/VCIClientTests/authorizationServer/PushedAuthorizationRequestServiceTests.swift
+++ b/Tests/VCIClientTests/authorizationServer/PushedAuthorizationRequestServiceTests.swift
@@ -167,6 +167,27 @@ final class PushedAuthorizationRequestServiceTests: XCTestCase {
         XCTAssertEqual(mock.capturedParams["client_id"], "real-client-id")
     }
 
+    func test_throwsWhenBothScopeAndAuthorizationDetailsAbsent() async {
+        let mock = makeMock(responseBody: validResponseBody)
+
+        do {
+            _ = try await PushedAuthorizationRequestService().pushAuthorizationRequest(
+                parEndpoint: parEndpoint,
+                clientId: "client-id",
+                redirectUri: "app://callback",
+                codeChallenge: "challenge",
+                state: "state-123",
+                nonce: "nonce-123",
+                session: mock
+            )
+            XCTFail("Expected PushedAuthorizationRequestException to be thrown")
+        } catch is PushedAuthorizationRequestException {
+            // expected
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
     func test_throwsWhenResponseHasNoRequestUri() async {
         let mock = makeMock(responseBody: "{}")
 

--- a/Tests/VCIClientTests/authorizationServer/PushedAuthorizationRequestServiceTests.swift
+++ b/Tests/VCIClientTests/authorizationServer/PushedAuthorizationRequestServiceTests.swift
@@ -74,6 +74,41 @@ final class PushedAuthorizationRequestServiceTests: XCTestCase {
         XCTAssertNil(body["authorization_details"])
     }
 
+    func test_sendsDpopJktWhenProvided() async throws {
+        let mock = makeMock(responseBody: validResponseBody)
+
+        _ = try await PushedAuthorizationRequestService().pushAuthorizationRequest(
+            parEndpoint: parEndpoint,
+            clientId: "client-id",
+            redirectUri: "app://callback",
+            codeChallenge: "challenge",
+            state: "state-123",
+            nonce: "nonce-123",
+            scope: "openid",
+            dpopJkt: "jkt-thumbprint",
+            session: mock
+        )
+
+        XCTAssertEqual(mock.capturedParams["dpop_jkt"], "jkt-thumbprint")
+    }
+
+    func test_omitsDpopJktWhenNotProvided() async throws {
+        let mock = makeMock(responseBody: validResponseBody)
+
+        _ = try await PushedAuthorizationRequestService().pushAuthorizationRequest(
+            parEndpoint: parEndpoint,
+            clientId: "client-id",
+            redirectUri: "app://callback",
+            codeChallenge: "challenge",
+            state: "state-123",
+            nonce: "nonce-123",
+            scope: "openid",
+            session: mock
+        )
+
+        XCTAssertNil(mock.capturedParams["dpop_jkt"])
+    }
+
     func test_mergesClientAuthParamsIntoBody() async throws {
         let mock = makeMock(responseBody: validResponseBody)
 

--- a/Tests/VCIClientTests/authorizationServer/PushedAuthorizationRequestServiceTests.swift
+++ b/Tests/VCIClientTests/authorizationServer/PushedAuthorizationRequestServiceTests.swift
@@ -149,6 +149,24 @@ final class PushedAuthorizationRequestServiceTests: XCTestCase {
         XCTAssertEqual(body["client_assertion"], "signed.jwt.value")
     }
 
+    func test_clientAuthParamsMustNotOverwriteCoreParams() async throws {
+        let mock = makeMock(responseBody: validResponseBody)
+
+        _ = try await PushedAuthorizationRequestService().pushAuthorizationRequest(
+            parEndpoint: parEndpoint,
+            clientId: "real-client-id",
+            redirectUri: "app://callback",
+            codeChallenge: "challenge",
+            state: "state-123",
+            nonce: "nonce-123",
+            scope: "openid",
+            clientAuthParams: ["client_id": "malicious-id"],
+            session: mock
+        )
+
+        XCTAssertEqual(mock.capturedParams["client_id"], "real-client-id")
+    }
+
     func test_throwsWhenResponseHasNoRequestUri() async {
         let mock = makeMock(responseBody: "{}")
 

--- a/Tests/VCIClientTests/dpop/AuthorizationUrlBuilderDPoPTests.swift
+++ b/Tests/VCIClientTests/dpop/AuthorizationUrlBuilderDPoPTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class AuthorizationUrlBuilderDPoPTests: XCTestCase {
     func test_appendsDpopJktWhenProvided() {
-        let url = AuthorizationUrlBuilder.build(
+        let url = AuthorizationUrlBuilder.buildWithParameters(
             baseUrl: "https://example.com/auth",
             clientId: "client",
             redirectUri: "https://app/callback",


### PR DESCRIPTION
### Implementation of PAR wrt to Specification
- AuthorizationServerMetadata: pushed_authorization_request_endpoint + require_pushed_authorization_requests
- PushedAuthorizationResponse model + PushedAuthorizationRequestException
- PushedAuthorizationRequestService (POST params -> request_uri)
- AuthorizationUrlBuilder.buildWithRequestUri (short client_id+request_uri URL)
- ImplicitAuthorizationRequestData carries PAR endpoint / authorization_details / issuer_state
- RedirectToWebAuthorizationMethodService branches to PAR when advertised, else falls back to the long-URL flow
- thread issuer_state + PAR endpoint through AuthorizationCodeFlowService
- unit tests for PushedAuthorizationRequestService

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Pushed Authorization Requests (PAR), including a new PAR push capability.
  * Enhanced redirect-to-web authorization to optionally use PAR and build authorization links using `request_uri`.
  * Extended authorization server metadata with PAR endpoint and “require PAR” support.
* **Bug Fixes**
  * Improved PAR/redirect-to-web error handling to preserve issuer error details when available.
* **Tests**
  * Added PAR service tests for request construction, response parsing, and error propagation (including DPoP/PKCE/client-auth rules).
  * Updated CI to run tests on an iOS 17.5 simulator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->