### PR TITLE
fix(ios): add DCP IAE support and address review feedback 

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -42,7 +42,7 @@
       "location" : "https://github.com/inji/inji-openid4vp-ios-swift",
       "state" : {
         "branch" : "develop",
-        "revision" : "2dbcd19d401ebaa96fb2b4c788b19f548485e733"
+        "revision" : "b5058ecb503e56582a318138cecc0b58c12c1059"
       }
     },
     {

--- a/Sources/VCIClient/authorizationCodeFlow/AuthorizationCodeFlowService.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/AuthorizationCodeFlowService.swift
@@ -229,12 +229,18 @@ class AuthorizationCodeFlowService {
         authorizationMethods: [AuthorizationMethod]
     ) async throws -> String {
     
+        let normalizedInteractiveEndpoint =
+            authorizationServerMetadata.interactiveAuthorizationEndpoint?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let hasInteractiveEndpoint =
+            !(normalizedInteractiveEndpoint?.isEmpty ?? true)
+
         if authorizationServerMetadata.requireInteractiveAuthorizationRequest == true ||
+           hasInteractiveEndpoint {
 
-           authorizationServerMetadata.interactiveAuthorizationEndpoint != nil {
-
-            guard let interactiveEndpoint = authorizationServerMetadata.interactiveAuthorizationEndpoint,
-                  !interactiveEndpoint.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            guard let interactiveEndpoint = normalizedInteractiveEndpoint,
+                  !interactiveEndpoint.isEmpty
             else {
                 throw DownloadFailedException(message: "Missing interactive authorization endpoint")
             }

--- a/Sources/VCIClient/authorizationCodeFlow/AuthorizationCodeFlowService.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/AuthorizationCodeFlowService.swift
@@ -254,11 +254,19 @@ class AuthorizationCodeFlowService {
                     authorizationMethods: authorizationMethods
                 )
             } catch let error as VCIClientException {
-                if error.issuerErrorCode == Constants.MISSING_INTERACTION_TYPE_ERROR {
-                    return try await obtainAuthorizationCodeViaAuthorizationEndpoint(authorizationServerMetadata: authorizationServerMetadata, issuerMetadata: issuerMetadata, clientMetadata: clientMetadata, pkceSession: pkceSession, authorizationMethods: authorizationMethods)
-                } else {
-                    throw error
+                if error.issuerErrorCode == Constants.MISSING_INTERACTION_TYPE_ERROR,
+                   authorizationServerMetadata.requireInteractiveAuthorizationRequest != true {
+
+                    return try await obtainAuthorizationCodeViaAuthorizationEndpoint(
+                        authorizationServerMetadata: authorizationServerMetadata,
+                        issuerMetadata: issuerMetadata,
+                        clientMetadata: clientMetadata,
+                        pkceSession: pkceSession,
+                        authorizationMethods: authorizationMethods
+                    )
                 }
+
+                throw error
             }
 
         } else {

--- a/Sources/VCIClient/authorizationCodeFlow/AuthorizationCodeFlowService.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/AuthorizationCodeFlowService.swift
@@ -228,9 +228,16 @@ class AuthorizationCodeFlowService {
         credentialConfigurationId: String,
         authorizationMethods: [AuthorizationMethod]
     ) async throws -> String {
-        let interactiveEndpoint = authorizationServerMetadata.interactiveAuthorizationEndpoint
+    
+        if authorizationServerMetadata.requireInteractiveAuthorizationRequest == true ||
 
-        if let interactiveEndpoint {
+           authorizationServerMetadata.interactiveAuthorizationEndpoint != nil {
+
+            guard let interactiveEndpoint = authorizationServerMetadata.interactiveAuthorizationEndpoint,
+                  !interactiveEndpoint.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            else {
+                throw DownloadFailedException(message: "Missing interactive authorization endpoint")
+            }
             do {
                 return try await obtainAuthorizationCodeViaInteractiveAuthorizationEndpoint(
                     endpoint: interactiveEndpoint,

--- a/Sources/VCIClient/authorizationCodeFlow/AuthorizationMethod.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/AuthorizationMethod.swift
@@ -18,7 +18,7 @@ public enum AuthorizationMethod {
         case .redirectToWeb:
             return .redirectToWeb
         case .presentationDuringIssuance:
-            return .openId4VpPresentation
+            return .openId4VpPresentationIAE
         }
     }
 }

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/Handler/InteractionType.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/Handler/InteractionType.swift
@@ -1,4 +1,5 @@
 enum InteractionType: String {
     case redirectToWeb = "redirect_to_web"
     case openId4VpPresentation = "openid4vp_presentation"
+    case openId4VpPresentationIAE = "urn:openid:dcp:iae:openid4vp_presentation"
 }

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/Handler/InteractiveAuthorizationHandler.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/Handler/InteractiveAuthorizationHandler.swift
@@ -43,7 +43,9 @@ class InteractiveAuthorizationHandler {
             
             let type: String = try extractTypeAndThrowIfError(interactiveAuthorizationResponse.body)
             
-            if type == InteractionType.openId4VpPresentation.rawValue {
+            if type == InteractionType.openId4VpPresentation.rawValue ||
+               type == InteractionType.openId4VpPresentationIAE.rawValue {
+
                 return try await handlePresentationInteraction(
                     presentationInteractionResponse: interactiveAuthorizationResponse.body,
                     authorizationMethods: authorizationMethods,

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/Handler/InteractiveAuthorizationHandler.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/Handler/InteractiveAuthorizationHandler.swift
@@ -16,11 +16,18 @@ class InteractiveAuthorizationHandler {
     ) async throws -> AuthorizationResponse {
         
         do {
-            let interactionTypesSupported = authorizationMethods.compactMap { method in
-                let type = method.type.rawValue
-                return type != InteractionType.redirectToWeb.rawValue ? type : nil
+            let interactionTypesSupported = authorizationMethods.flatMap { method -> [String] in
+                switch method {
+                case .redirectToWeb:
+                    return []
+
+                case .presentationDuringIssuance:
+                    return [
+                        InteractionType.openId4VpPresentation.rawValue,
+                        InteractionType.openId4VpPresentationIAE.rawValue
+                    ]
+                }
             }
-            
             if interactionTypesSupported.isEmpty {
                 throw InteractiveAuthorizationException(
                     message: "No supported interaction types found in authorization methods"
@@ -146,7 +153,9 @@ class InteractiveAuthorizationHandler {
         }
         
         guard
-            case let .presentationDuringIssuance(jsonLdCanonicalizer, openid4vpWalletConfig, selectCredentialsForPresentation, signVerifiablePresentation) = authorizationMethods.first(where: { $0.type == .openId4VpPresentation })
+            case let .presentationDuringIssuance(jsonLdCanonicalizer, openid4vpWalletConfig, selectCredentialsForPresentation, signVerifiablePresentation) = authorizationMethods.first(where: {
+                $0.type == .openId4VpPresentationIAE
+            })
         else {
             throw InteractiveAuthorizationException(message: "Presentation callback missing")
         }

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.swift
@@ -78,10 +78,10 @@ class PresentationDuringIssuanceAuthorizationMethodService: AuthorizationMethodS
         let authorizationRequest = try await openId4vp.authenticateVerifier(authRequest: request)
         guard authorizationRequest.responseMode == "iar-post"
            || authorizationRequest.responseMode == "iar-post.jwt"
-           || authorizationRequest.responseMode == "iae-post"
-           || authorizationRequest.responseMode == "iae-post.jwt" else {
+           || authorizationRequest.responseMode == "iae_post"
+           || authorizationRequest.responseMode == "iae_post.jwt" else {
             throw IllegalArgumentException(
-                "response_mode must be 'iar-post', 'iar-post.jwt', 'iae-post' or 'iae-post.jwt'"
+                "response_mode must be 'iar-post', 'iar-post.jwt', 'iae_post' or 'iae_post.jwt'"
             )
         }
         return authorizationRequest

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.swift
@@ -25,7 +25,7 @@ class PresentationDuringIssuanceAuthorizationMethodService: AuthorizationMethodS
     }
 
     func type() -> String {
-        return InteractionType.openId4VpPresentation.rawValue
+        return InteractionType.openId4VpPresentationIAE.rawValue
     }
 
     func authorizeUser(requestData: AuthorizationRequestData) async throws -> AuthorizationResponse {

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodService.swift
@@ -77,8 +77,12 @@ class PresentationDuringIssuanceAuthorizationMethodService: AuthorizationMethodS
     private func validatePresentationRequest(request: [String: Any]) async throws -> AuthorizationRequest {
         let authorizationRequest = try await openId4vp.authenticateVerifier(authRequest: request)
         guard authorizationRequest.responseMode == "iar-post"
-                || authorizationRequest.responseMode == "iar-post.jwt" else {
-            throw IllegalArgumentException("response_mode must be 'iar-post' or 'iar-post.jwt'")
+           || authorizationRequest.responseMode == "iar-post.jwt"
+           || authorizationRequest.responseMode == "iae-post"
+           || authorizationRequest.responseMode == "iae-post.jwt" else {
+            throw IllegalArgumentException(
+                "response_mode must be 'iar-post', 'iar-post.jwt', 'iae-post' or 'iae-post.jwt'"
+            )
         }
         return authorizationRequest
     }

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationInteractionResponse.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationInteractionResponse.swift
@@ -82,11 +82,11 @@ final class PresentationInteractionResponse: InteractionResponse, Decodable {
     
     override func validate() throws {
         guard let type = type,
-              type == "openid4vp_presentation"
-                || type == "urn:openid:dcp:iae:openid4vp_presentation"
+              type == InteractionType.openId4VpPresentation.rawValue
+                || type == InteractionType.openId4VpPresentationIAE.rawValue
         else {
             throw IllegalArgumentException(
-                "Invalid type: expected 'openid4vp_presentation' or 'urn:openid:dcp:iae:openid4vp_presentation'"
+                "Invalid type: expected '\(InteractionType.openId4VpPresentation.rawValue)' or '\(InteractionType.openId4VpPresentationIAE.rawValue)'"
             )
         }
         

--- a/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationInteractionResponse.swift
+++ b/Sources/VCIClient/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationInteractionResponse.swift
@@ -2,14 +2,14 @@ import Foundation
 
 final class PresentationInteractionResponse: InteractionResponse, Decodable {
     var openid4vpRequest: [String: Any]
-
+    
     private enum CodingKeys: String, CodingKey {
         case status
         case type
         case authSession = "auth_session"
         case openid4vpRequest = "openid4vp_request"
     }
-
+    
     init(json: [String: Any]) throws {
         guard let request = json["openid4vp_request"] as? [String: Any] else {
             throw IllegalArgumentException("Missing or invalid 'openid4vp_request'")
@@ -24,7 +24,7 @@ final class PresentationInteractionResponse: InteractionResponse, Decodable {
         let status = try container.decode(String.self, forKey: .status)
         let type = try container.decode(String.self, forKey: .type)
         let authSession = try container.decode(String.self, forKey: .authSession)
-
+        
         if let nestedDecoder = try? container.superDecoder(forKey: .openid4vpRequest) {
             let any = try PresentationInteractionResponse.decodeAny(from: nestedDecoder)
             guard let dict = any as? [String: Any] else {
@@ -41,7 +41,7 @@ final class PresentationInteractionResponse: InteractionResponse, Decodable {
         }
         try super.init(status: status, type: type,  authSession: authSession)
     }
-
+    
     private static func decodeAny(from decoder: Decoder) throws -> Any {
         if var arrayContainer = try? decoder.unkeyedContainer() {
             var arr: [Any] = []
@@ -72,7 +72,7 @@ final class PresentationInteractionResponse: InteractionResponse, Decodable {
         }
         throw ValidationError.invalid("Unsupported JSON value")
     }
-
+    
     private struct DynamicCodingKeys: CodingKey {
         var stringValue: String
         init?(stringValue: String) { self.stringValue = stringValue }
@@ -81,24 +81,30 @@ final class PresentationInteractionResponse: InteractionResponse, Decodable {
     }
     
     override func validate() throws {
-        guard let type = type, type == "openid4vp_presentation" else {
-            throw IllegalArgumentException("Invalid type: expected 'openid4vp_presentation'")
+        guard let type = type,
+              type == "openid4vp_presentation"
+                || type == "urn:openid:dcp:iae:openid4vp_presentation"
+        else {
+            throw IllegalArgumentException(
+                "Invalid type: expected 'openid4vp_presentation' or 'urn:openid:dcp:iae:openid4vp_presentation'"
+            )
         }
-
+        
         guard !openid4vpRequest.isEmpty else {
             throw IllegalArgumentException("openid4vpRequest must not be empty")
         }
+        
     }
-}
-
-
-
-enum ValidationError: Error {
-    case invalidStatus(String)
-    case invalidType(String)
-    case blankAuthSession
-    case emptyOpenId4VpRequest
-    case missing(String)
-    case invalid(String)
-    case blank(String)
+    
+    
+    enum ValidationError: Error {
+        case invalidStatus(String)
+        case invalidType(String)
+        case blankAuthSession
+        case emptyOpenId4VpRequest
+        case missing(String)
+        case invalid(String)
+        case blank(String)
+        
+    }
 }

--- a/Sources/VCIClient/authorizationServer/AuthorizationServerMetadata.swift
+++ b/Sources/VCIClient/authorizationServer/AuthorizationServerMetadata.swift
@@ -6,6 +6,7 @@ struct AuthorizationServerMetadata: Codable {
     let tokenEndpoint: String?
     let authorizationEndpoint: String?
     let interactiveAuthorizationEndpoint: String?
+    let requireInteractiveAuthorizationRequest: Bool?
 
     enum CodingKeys: String, CodingKey {
         case issuer
@@ -13,6 +14,7 @@ struct AuthorizationServerMetadata: Codable {
         case tokenEndpoint = "token_endpoint"
         case authorizationEndpoint = "authorization_endpoint"
         case interactiveAuthorizationEndpoint = "interactive_authorization_endpoint"
+        case requireInteractiveAuthorizationRequest = "require_interactive_authorization_request"
     }
 }
 

--- a/Sources/VCIClient/authorizationServer/AuthorizationServerResolver.swift
+++ b/Sources/VCIClient/authorizationServer/AuthorizationServerResolver.swift
@@ -89,9 +89,15 @@ class AuthorizationServerResolver {
             )
         }
         if expectedGrantType == GrantType.authorizationCode.rawValue,
-           // either authorization_endpoint or interactive_authorization_endpoint is required
-           (authServerMetadata.authorizationEndpoint == nil || authServerMetadata.authorizationEndpoint?.isEmpty == true) &&
-           (authServerMetadata.interactiveAuthorizationEndpoint == nil || authServerMetadata.interactiveAuthorizationEndpoint?.isEmpty == true)
+           (authServerMetadata.authorizationEndpoint == nil ||
+            authServerMetadata.authorizationEndpoint?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .isEmpty == true) &&
+           (authServerMetadata.interactiveAuthorizationEndpoint == nil ||
+            authServerMetadata.interactiveAuthorizationEndpoint?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .isEmpty == true) &&
+           authServerMetadata.requireInteractiveAuthorizationRequest != true
         {
             throw AuthorizationServerDiscoveryException(
                 "Missing authorization_endpoint for authorization_code flow."

--- a/Sources/VCIClient/authorizationServer/AuthorizationServerResolver.swift
+++ b/Sources/VCIClient/authorizationServer/AuthorizationServerResolver.swift
@@ -96,8 +96,7 @@ class AuthorizationServerResolver {
            (authServerMetadata.interactiveAuthorizationEndpoint == nil ||
             authServerMetadata.interactiveAuthorizationEndpoint?
                 .trimmingCharacters(in: .whitespacesAndNewlines)
-                .isEmpty == true) &&
-           authServerMetadata.requireInteractiveAuthorizationRequest != true
+                .isEmpty == true) 
         {
             throw AuthorizationServerDiscoveryException(
                 "Missing authorization_endpoint for authorization_code flow."

--- a/Tests/VCIClientTests/authorizationCodeFlow/AuthorizationCodeFlowServiceTests.swift
+++ b/Tests/VCIClientTests/authorizationCodeFlow/AuthorizationCodeFlowServiceTests.swift
@@ -119,7 +119,8 @@ final class AuthorizationCodeFlowServiceTests: XCTestCase {
         resolver.mockTokenEndpoint = "https://auth.example.com/token"
         resolver.mcokAuthorizationEndpoint = nil
         resolver.mockInteractiveAuthorizationEndpoint = "https://auth.example.com/interactive"
-
+        resolver.mockRequireInteractiveAuthorizationRequest = true
+        
         let interactiveHandler = MockInteractiveAuthorizationHandler()
         interactiveHandler.responseToReturn = AuthorizationResponse(
             authorizationCode: "interactive-code",
@@ -170,6 +171,7 @@ final class AuthorizationCodeFlowServiceTests: XCTestCase {
     func test_interactiveAuth_missingInteractionType_shouldFallbackToAuthorizationEndpoint() async throws {
         let resolver = MockAuthServerResolver()
         resolver.mockInteractiveAuthorizationEndpoint = "https://auth.example.com/interactive"
+        resolver.mockRequireInteractiveAuthorizationRequest = true
 
         let interactiveHandler = MockInteractiveAuthorizationHandler()
         interactiveHandler.shouldThrowMissingInteractionType = true
@@ -201,6 +203,7 @@ final class AuthorizationCodeFlowServiceTests: XCTestCase {
         resolver.mockTokenEndpoint = "https://auth.example.com/token"
         resolver.mcokAuthorizationEndpoint = nil
         resolver.mockInteractiveAuthorizationEndpoint = "https://auth.example.com/interactive"
+        resolver.mockRequireInteractiveAuthorizationRequest = true
 
         let interactiveHandler = MockInteractiveAuthorizationHandler()
         interactiveHandler.errorToThrow = InteractiveAuthorizationException(message: "missing_interaction_type")

--- a/Tests/VCIClientTests/authorizationCodeFlow/AuthorizationCodeFlowServiceTests.swift
+++ b/Tests/VCIClientTests/authorizationCodeFlow/AuthorizationCodeFlowServiceTests.swift
@@ -171,7 +171,7 @@ final class AuthorizationCodeFlowServiceTests: XCTestCase {
     func test_interactiveAuth_missingInteractionType_shouldFallbackToAuthorizationEndpoint() async throws {
         let resolver = MockAuthServerResolver()
         resolver.mockInteractiveAuthorizationEndpoint = "https://auth.example.com/interactive"
-        resolver.mockRequireInteractiveAuthorizationRequest = true
+        resolver.mockRequireInteractiveAuthorizationRequest = false
 
         let interactiveHandler = MockInteractiveAuthorizationHandler()
         interactiveHandler.shouldThrowMissingInteractionType = true
@@ -196,6 +196,44 @@ final class AuthorizationCodeFlowServiceTests: XCTestCase {
         XCTAssertEqual(result.credential.value as? String, "mock-credential")
     }
 
+    func test_interactiveAuth_missingInteractionType_shouldNotFallbackWhenInteractiveAuthorizationIsRequired() async {
+
+        let resolver = MockAuthServerResolver()
+        resolver.mockInteractiveAuthorizationEndpoint = "https://auth.example.com/interactive"
+        resolver.mockRequireInteractiveAuthorizationRequest = true
+
+        let interactiveHandler = MockInteractiveAuthorizationHandler()
+        interactiveHandler.shouldThrowMissingInteractionType = true
+
+        let service = makeService(
+            resolver: resolver,
+            interactiveAuthHandler: interactiveHandler
+        )
+
+        await XCTAssertThrowsErrorAsync {
+            _ = try await service.requestCredentialsDraft13(
+                issuerMetadata: IssuerMetadata.mock(),
+                clientMetadata: ClientMetadata(clientId: "client123", redirectUri: "app://redirect"),
+                authorizationMethods: [
+                    .redirectToWeb(openWebPage: { _ in ["code": "fallback-auth-code"] }),
+                ],
+                getTokenResponse: { _ in
+                    TokenResponse(accessToken: "mock-token", tokenType: "Bearer")
+                },
+                getProofJwt: { _, _, _ in "mock-jwt" },
+                credentialConfigurationId: "vc1",
+                proofSigningAlgorithmsSupported: ["rs256"]
+            )
+        } verify: { error in
+            let downloadError = error as? DownloadFailedException
+            XCTAssertNotNil(downloadError)
+            XCTAssertEqual(
+                downloadError?.issuerErrorCode,
+                Constants.MISSING_INTERACTION_TYPE_ERROR
+            )
+        }
+    }
+    
     func test_requestCredentials_whenInteractiveAuthorizationIsMissingType_wrapsFailure() async {
         let resolver = MockAuthServerResolver()
         resolver.mockIssuer = "https://auth.example.com"

--- a/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/Handler/InteractiveAuthorizationHandlerTests.swift
+++ b/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/Handler/InteractiveAuthorizationHandlerTests.swift
@@ -81,7 +81,54 @@ final class InteractiveAuthorizationHandlerTests: XCTestCase {
         XCTAssertEqual(response.status, "require_interaction")
         XCTAssertEqual(response.authSession, "auth-session-1")
     }
+    
+    func test_handle_success_openId4VpPresentationIAE_flow() async throws {
 
+        let initialNetwork = MockNetworkManager()
+
+        let presentationJSON: [String: Any] = [
+            "status": "require_interaction",
+            "type": InteractionType.openId4VpPresentationIAE.rawValue,
+            "auth_session": "auth-session-1",
+            "openid4vp_request": [
+                "response_type": "vp_token",
+                "response_mode": "iar-post"
+            ]
+        ]
+
+        let initialBody = try JSONSerialization.data(withJSONObject: presentationJSON)
+        initialNetwork.responseBody = String(data: initialBody, encoding: .utf8) ?? ""
+
+        let select: SelectCredentialsForPresentationCallback = { _ in
+            return [
+                "cred1": [
+                    OpenID4VPCredential(
+                        format: .ldp_vc,
+                        data: OpenID4VPAnyCodable("dummy-cred"),
+                        credentialId: "cred1"
+                    )
+                ]
+            ]
+        }
+
+        let sign: SignVerifiablePresentationCallback = { _ in
+            return []
+        }
+
+        let handler = InteractiveAuthorizationHandler(networkManager: initialNetwork)
+
+        let response = try await handler.handle(
+            endpoint: "https://issuer.example.com/iar",
+            clientMetadata: self.makeClientMetadata(),
+            credentialConfigurationId: "cfg-1",
+            authorizationMethods: makeAuthMethods(select: select, sign: sign),
+            pkceSession: self.makePKCE()
+        )
+
+        XCTAssertEqual(response.status, "require_interaction")
+        XCTAssertEqual(response.authSession, "auth-session-1")
+    }
+    
     // MARK: - Failure: invalid JSON
 
     func test_handle_extractInteractionType_invalidJSON_throws() async {

--- a/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodServiceTests.swift
+++ b/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodServiceTests.swift
@@ -160,7 +160,7 @@ final class PresentationDuringIssuanceAuthorizationMethodServiceTests: XCTestCas
         let sut = makeService(openId4vp: FakeOpenID4VP())
         XCTAssertEqual(
             sut.type(),
-            InteractionType.openId4VpPresentation.rawValue
+            InteractionType.openId4VpPresentationIAE.rawValue
         )
     }
 

--- a/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodServiceTests.swift
+++ b/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodServiceTests.swift
@@ -215,7 +215,7 @@ final class PresentationDuringIssuanceAuthorizationMethodServiceTests: XCTestCas
     
     func test_full_success_flow_accepts_supported_iae_response_modes() async throws {
 
-        for responseMode in ["iae-post", "iae-post.jwt"] {
+        for responseMode in ["iae_post", "iae_post.jwt"] {
 
             let fake = FakeOpenID4VP()
             let network = MockNetworkManager()
@@ -310,7 +310,7 @@ final class PresentationDuringIssuanceAuthorizationMethodServiceTests: XCTestCas
         XCTAssertFalse(didSelectCredentials)
         XCTAssertEqual(
             fake.constructedError?.localizedDescription,
-            "response_mode must be 'iar-post', 'iar-post.jwt', 'iae-post' or 'iae-post.jwt'"
+            "response_mode must be 'iar-post', 'iar-post.jwt', 'iae_post' or 'iae_post.jwt'"
         )
     }
 

--- a/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodServiceTests.swift
+++ b/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationDuringIssuanceAuthorizationMethodServiceTests.swift
@@ -212,7 +212,42 @@ final class PresentationDuringIssuanceAuthorizationMethodServiceTests: XCTestCas
         XCTAssertEqual(network.capturedParams["auth_session"], "auth-session-1")
         XCTAssertNotNil(network.capturedParams["openid4vp_response"])
     }
+    
+    func test_full_success_flow_accepts_supported_iae_response_modes() async throws {
 
+        for responseMode in ["iae-post", "iae-post.jwt"] {
+
+            let fake = FakeOpenID4VP()
+            let network = MockNetworkManager()
+
+            let success = AuthorizationResponse(
+                authorizationCode: "code-123",
+                status: "success",
+                error: nil,
+                errorDescription: nil,
+                authSession: "auth-session-1"
+            )
+
+            network.responseBody =
+                String(data: try JSONEncoder().encode(success), encoding: .utf8)!
+
+            var request = authorizationRequest
+            request["response_mode"] = responseMode
+
+            let sut = makeService(
+                openId4vp: fake,
+                network: network
+            )
+
+            let response = try await sut.authorizeUser(
+                requestData: makeRequestData(ovpRequest: request)
+            )
+
+            XCTAssertEqual(response.status, "success")
+            XCTAssertEqual(response.authorizationCode, "code-123")
+        }
+    }
+    
     // MARK: - Empty selection
 
     func test_empty_selection_maps_to_access_denied_and_posts() async throws {
@@ -275,7 +310,7 @@ final class PresentationDuringIssuanceAuthorizationMethodServiceTests: XCTestCas
         XCTAssertFalse(didSelectCredentials)
         XCTAssertEqual(
             fake.constructedError?.localizedDescription,
-            "response_mode must be 'iar-post' or 'iar-post.jwt'"
+            "response_mode must be 'iar-post', 'iar-post.jwt', 'iae-post' or 'iae-post.jwt'"
         )
     }
 

--- a/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationInteractionResponseTests.swift
+++ b/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationInteractionResponseTests.swift
@@ -121,4 +121,48 @@ final class PresentationInteractionResponseTests: XCTestCase {
 
         XCTAssertThrowsError(try response.validate())
     }
+    func testValidate_acceptsDcpInteractionType() throws {
+        let response = try PresentationInteractionResponse(
+            json: [
+                "status": "require_interaction",
+                "type": "urn:openid:dcp:iae:openid4vp_presentation",
+                "auth_session": "session-1",
+                "openid4vp_request": [
+                    "response_type": "vp_token"
+                ]
+            ]
+        )
+
+        XCTAssertNoThrow(try response.validate())
+    }
+    
+    func testValidate_acceptsSupportedResponseModes() throws {
+
+        let responseModes = [
+            "iae_post",
+            "iae_post.jwt"
+        ]
+
+        for mode in responseModes {
+
+            let response = try PresentationInteractionResponse(
+                json: [
+                    "status": "require_interaction",
+                    "type": "openid4vp_presentation",
+                    "auth_session": "session-1",
+                    "openid4vp_request": [
+                        "response_type": "vp_token",
+                        "response_mode": mode
+                    ]
+                ]
+            )
+
+            XCTAssertNoThrow(
+                try response.validate(),
+                "Expected response mode \(mode) to be accepted"
+            )
+        }
+    }
+   
+   
 }

--- a/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationInteractionResponseTests.swift
+++ b/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/PresentationDuringIssuance/PresentationInteractionResponseTests.swift
@@ -136,33 +136,4 @@ final class PresentationInteractionResponseTests: XCTestCase {
         XCTAssertNoThrow(try response.validate())
     }
     
-    func testValidate_acceptsSupportedResponseModes() throws {
-
-        let responseModes = [
-            "iae_post",
-            "iae_post.jwt"
-        ]
-
-        for mode in responseModes {
-
-            let response = try PresentationInteractionResponse(
-                json: [
-                    "status": "require_interaction",
-                    "type": "openid4vp_presentation",
-                    "auth_session": "session-1",
-                    "openid4vp_request": [
-                        "response_type": "vp_token",
-                        "response_mode": mode
-                    ]
-                ]
-            )
-
-            XCTAssertNoThrow(
-                try response.validate(),
-                "Expected response mode \(mode) to be accepted"
-            )
-        }
-    }
-   
-   
 }

--- a/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/Request/AuthorizationModelTests.swift
+++ b/Tests/VCIClientTests/authorizationCodeFlow/InteractiveAuthorization/Request/AuthorizationModelTests.swift
@@ -102,6 +102,34 @@ final class AuthorizationModelTests: XCTestCase {
         XCTAssertEqual(authDetailsParsed?.first?["credential_configuration_id"] as? String, "cfg1")
     }
 
+    
+    func test_IARInitialRequestBody_toFormMap_includesLegacyAndIAEInteractionTypes() throws {
+
+        let details = [
+            AuthorizationDetails(
+                type: "openid_credential",
+                credentialConfigurationId: "cfg1"
+            )
+        ]
+
+        let body = IARInitialRequestBody(
+            clientId: "client-123",
+            codeChallenge: "challenge",
+            redirectUri: "app://callback",
+            authorizationDetails: details,
+            interactionTypesSupported: [
+                InteractionType.openId4VpPresentation.rawValue,
+                InteractionType.openId4VpPresentationIAE.rawValue
+            ]
+        )
+
+        let form = body.toFormMap()
+
+        XCTAssertEqual(
+            form["interaction_types_supported"],
+            "\(InteractionType.openId4VpPresentation.rawValue),\(InteractionType.openId4VpPresentationIAE.rawValue)"
+        )
+    }
     // MARK: - AuthorizationResponse (Codable)
 
     func test_AuthorizationResponse_success_decode_encode() throws {

--- a/Tests/VCIClientTests/authorizationServer/AuthorizationServerResolverTests.swift
+++ b/Tests/VCIClientTests/authorizationServer/AuthorizationServerResolverTests.swift
@@ -8,7 +8,8 @@ final class AuthorizationServerResolverTests: XCTestCase {
         mockDiscovery.mockMetadataByUrl[url] = AuthorizationServerMetadata(
             issuer: url,
             grantTypesSupported: ["authorization_code"], tokenEndpoint: "https://mock-token",
-            authorizationEndpoint: "\(url)/auth", interactiveAuthorizationEndpoint: nil
+            authorizationEndpoint: "\(url)/auth", interactiveAuthorizationEndpoint: nil,
+            requireInteractiveAuthorizationRequest: nil
         )
 
         let resolver = AuthorizationServerResolver(authServerDiscoveryService: mockDiscovery)
@@ -29,7 +30,8 @@ final class AuthorizationServerResolverTests: XCTestCase {
             issuer: overrideUrl,
             grantTypesSupported: ["authorization_code"], tokenEndpoint: "mock",
             authorizationEndpoint: "\(overrideUrl)/auth",
-            interactiveAuthorizationEndpoint: nil
+            interactiveAuthorizationEndpoint: nil,
+            requireInteractiveAuthorizationRequest: nil
         )
 
         let resolver = AuthorizationServerResolver(authServerDiscoveryService: mockDiscovery)
@@ -50,7 +52,8 @@ final class AuthorizationServerResolverTests: XCTestCase {
             issuer: "https://valid.com",
             grantTypesSupported: ["authorization_code"], tokenEndpoint: "mock-token",
             authorizationEndpoint: "https://valid.com/auth",
-            interactiveAuthorizationEndpoint: nil
+            interactiveAuthorizationEndpoint: nil,
+            requireInteractiveAuthorizationRequest: nil
         )
 
         let resolver = AuthorizationServerResolver(authServerDiscoveryService: mockDiscovery)
@@ -97,7 +100,8 @@ final class AuthorizationServerResolverTests: XCTestCase {
             issuer: fallback,
             grantTypesSupported: ["authorization_code"], tokenEndpoint: "mock-token",
             authorizationEndpoint: "\(fallback)/auth",
-            interactiveAuthorizationEndpoint: nil
+            interactiveAuthorizationEndpoint: nil,
+            requireInteractiveAuthorizationRequest: nil
         )
 
         let resolver = AuthorizationServerResolver(authServerDiscoveryService: mockDiscovery)
@@ -120,7 +124,9 @@ final class AuthorizationServerResolverTests: XCTestCase {
             issuer: "https://mismatch.com",
             grantTypesSupported: ["authorization_code"], tokenEndpoint: "mock",
             authorizationEndpoint: "\(realUrl)/auth",
-            interactiveAuthorizationEndpoint: nil
+            interactiveAuthorizationEndpoint: nil,
+            requireInteractiveAuthorizationRequest: nil
+            
         )
 
         let resolver = AuthorizationServerResolver(authServerDiscoveryService: mockDiscovery)
@@ -148,7 +154,8 @@ final class AuthorizationServerResolverTests: XCTestCase {
             issuer: url,
             grantTypesSupported: ["implicit"], tokenEndpoint: "mock",
             authorizationEndpoint: "\(url)/auth",
-            interactiveAuthorizationEndpoint: nil
+            interactiveAuthorizationEndpoint: nil,
+            requireInteractiveAuthorizationRequest: nil
         )
 
         let resolver = AuthorizationServerResolver(authServerDiscoveryService: mockDiscovery)

--- a/Tests/VCIClientTests/mocks/MockServices.swift
+++ b/Tests/VCIClientTests/mocks/MockServices.swift
@@ -10,13 +10,16 @@ final class MockAuthServerResolver: AuthorizationServerResolver {
     var mcokAuthorizationEndpoint: String? = "https://example.com/auth"
     var mockInteractiveAuthorizationEndpoint: String?
     var mockGrantTypesSupported: [String]? = nil
+    var mockRequireInteractiveAuthorizationRequest: Bool? = nil
+    
     override func resolveForPreAuth(issuerMetadata: IssuerMetadata, credentialOffer: CredentialOffer) async throws -> AuthorizationServerMetadata {
         return AuthorizationServerMetadata(
             issuer: mockIssuer,
             grantTypesSupported: mockGrantTypesSupported,
             tokenEndpoint: mockTokenEndpoint,
             authorizationEndpoint: nil,
-            interactiveAuthorizationEndpoint: mockInteractiveAuthorizationEndpoint
+            interactiveAuthorizationEndpoint: mockInteractiveAuthorizationEndpoint,
+            requireInteractiveAuthorizationRequest: mockRequireInteractiveAuthorizationRequest
         )
     }
 
@@ -27,7 +30,8 @@ final class MockAuthServerResolver: AuthorizationServerResolver {
             grantTypesSupported: mockGrantTypesSupported,
             tokenEndpoint: mockTokenEndpoint,
             authorizationEndpoint: mcokAuthorizationEndpoint,
-            interactiveAuthorizationEndpoint: mockInteractiveAuthorizationEndpoint
+            interactiveAuthorizationEndpoint: mockInteractiveAuthorizationEndpoint,
+            requireInteractiveAuthorizationRequest: mockRequireInteractiveAuthorizationRequest
         )
     }
 }


### PR DESCRIPTION
* fix(ios): add DCP IAE support and address review feedback



* fix: address review feedback



* fix: remove unused validation logic and address review feedback



---------

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the DCP-specific OpenID4VP presentation interaction type during credential issuance.
  * Added support for marking interactive authorization requests as required via `require_interactive_authorization_request`.

* **Bug Fixes**
  * Interactive authorization endpoint discovery now trims whitespace and treats empty values as missing.
  * Improved interactive interaction-type handling and fallback behavior to respect the “required” metadata flag.

* **Tests**
  * Expanded unit tests to cover the new interaction type, supported IAE response modes, and required vs non-required interactive authorization scenarios.

* **Chores**
  * Updated a pinned dependency revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->