### PR TITLE
fix(dpop): add DPoP exception

### DIFF
--- a/Sources/VCIClient/dpop/DPoPAlgorithm.swift
+++ b/Sources/VCIClient/dpop/DPoPAlgorithm.swift
@@ -42,10 +42,7 @@ enum DPoPAlgorithm: String {
     private func generateEcKeyMaterial() throws -> DPoPKeyMaterial {
         let (keyType, curve) = ellipticParameters()
         guard let generator = JWK(keyType: keyType, curve: curve).keyGeneration else {
-            throw VCIClientException(
-                code: "VCI-011",
-                message: "Unable to generate a DPoP key for algorithm \(rawValue)"
-            )
+            throw DPoPException("Unable to generate a DPoP key for algorithm \(rawValue)")
         }
         let privateKey = try generator.generateKeyPairJWK(purpose: .signing)
         return DPoPKeyMaterial(
@@ -63,24 +60,18 @@ enum DPoPAlgorithm: String {
         ]
         var genError: Unmanaged<CFError>?
         guard let privateSecKey = SecKeyCreateRandomKey(attributes as CFDictionary, &genError) else {
-            throw VCIClientException(
-                code: "VCI-011",
-                message: "RSA key generation failed: \(genError!.takeRetainedValue())"
-            )
+            throw DPoPException("RSA key generation failed: \(genError!.takeRetainedValue())")
         }
         var exportError: Unmanaged<CFError>?
         guard let keyData = SecKeyCopyExternalRepresentation(privateSecKey, &exportError) as Data? else {
-            throw VCIClientException(
-                code: "VCI-011",
-                message: "RSA key export failed: \(exportError!.takeRetainedValue())"
-            )
+            throw DPoPException("RSA key export failed: \(exportError!.takeRetainedValue())")
         }
         // Build from parsed components rather than RSA(rawRepresentation:); see RSAKeyDER.
         let components = try RSAKeyDER.privateComponents(keyData)
         let privateKey = CryptoSwift.RSA(n: components.n, e: components.e, d: components.d)
         let fullJWK = privateKey.jwkRepresentation
         guard let n = fullJWK.n, let e = fullJWK.e else {
-            throw VCIClientException(code: "VCI-011", message: "Unable to extract RSA public key components")
+            throw DPoPException("Unable to extract RSA public key components")
         }
         return DPoPKeyMaterial(signingKey: privateKey, publicJWK: JWK(keyType: .rsa, e: e, n: n))
     }
@@ -114,10 +105,9 @@ enum DPoPAlgorithm: String {
         let preferenceOrder: [DPoPAlgorithm] = [.eddsa, .es256k, .es256, .es384, .es512, .rs256]
         guard let match = preferenceOrder.first(where: { supported.contains($0.rawValue) }) else {
             let clientSupported = preferenceOrder.map(\.rawValue).joined(separator: ", ")
-            throw VCIClientException(
-                code: "VCI-012",
-                message: "No supported DPoP algorithm found. AS supports: \(supported), " +
-                         "client supports: [\(clientSupported)]"
+            throw DPoPException(
+                "No supported DPoP algorithm found. AS supports: \(supported), " +
+                "client supports: [\(clientSupported)]"
             )
         }
         return match

--- a/Sources/VCIClient/dpop/DPoPManager.swift
+++ b/Sources/VCIClient/dpop/DPoPManager.swift
@@ -22,14 +22,23 @@ class DPoPManager {
 
     func initialize(tokenEndpoint: String, authorizationServerSupportedAlgorithms: [String]?) throws {
         guard session == nil else { return }
-        let algorithm = try DPoPAlgorithm.select(authorizationServerSupportedAlgorithms)
-        let material = try algorithm.generateKeyMaterial()
-        session = Session(
-            signingKey: material.signingKey,
-            publicJWK: material.publicJWK,
-            algorithm: algorithm,
-            tokenEndpoint: DPoPManager.normalizeHtu(tokenEndpoint)
-        )
+        do {
+            let algorithm = try DPoPAlgorithm.select(authorizationServerSupportedAlgorithms)
+            let material = try algorithm.generateKeyMaterial()
+            session = Session(
+                signingKey: material.signingKey,
+                publicJWK: material.publicJWK,
+                algorithm: algorithm,
+                tokenEndpoint: DPoPManager.normalizeHtu(tokenEndpoint)
+            )
+        } catch let e as DPoPException {
+            throw e
+        } catch {
+            throw DPoPException(
+                message: "Unexpected error while initializing the DPoP session: \(error.localizedDescription)",
+                cause: error
+            )
+        }
     }
 
     func reset() {
@@ -44,12 +53,30 @@ class DPoPManager {
     }
 
     func jwkThumbprint() throws -> String {
-        try DPoPManager.thumbprint(of: requireSession().publicJWK)
+        do {
+            return try DPoPManager.thumbprint(of: requireSession().publicJWK)
+        } catch let e as DPoPException {
+            throw e
+        } catch {
+            throw DPoPException(
+                message: "Unexpected error while computing the DPoP JWK thumbprint: \(error.localizedDescription)",
+                cause: error
+            )
+        }
     }
 
     func generateTokenProof(nonce: String? = nil) throws -> String {
-        let activeSession = try requireSession()
-        return try buildProof(activeSession, htu: activeSession.tokenEndpoint, nonce: nonce, accessToken: nil)
+        do {
+            let activeSession = try requireSession()
+            return try buildProof(activeSession, htu: activeSession.tokenEndpoint, nonce: nonce, accessToken: nil)
+        } catch let e as DPoPException {
+            throw e
+        } catch {
+            throw DPoPException(
+                message: "Unexpected error while generating the token DPoP proof: \(error.localizedDescription)",
+                cause: error
+            )
+        }
     }
 
     func generateCredentialProof(
@@ -57,14 +84,23 @@ class DPoPManager {
         accessToken: String,
         nonce: String? = nil
     ) throws -> String {
-        let activeSession = try requireSession()
-        updateNonce(nonce)
-        return try buildProof(
-            activeSession,
-            htu: DPoPManager.normalizeHtu(credentialEndpoint),
-            nonce: issuerNonce,
-            accessToken: accessToken
-        )
+        do {
+            let activeSession = try requireSession()
+            updateNonce(nonce)
+            return try buildProof(
+                activeSession,
+                htu: DPoPManager.normalizeHtu(credentialEndpoint),
+                nonce: issuerNonce,
+                accessToken: accessToken
+            )
+        } catch let e as DPoPException {
+            throw e
+        } catch {
+            throw DPoPException(
+                message: "Unexpected error while generating the credential DPoP proof: \(error.localizedDescription)",
+                cause: error
+            )
+        }
     }
 
     private func buildProof(
@@ -97,10 +133,7 @@ class DPoPManager {
 
     private func requireSession() throws -> Session {
         guard let session = session else {
-            throw VCIClientException(
-                code: "VCI-011",
-                message: "DPoP session is not initialized for the current flow"
-            )
+            throw DPoPException("DPoP session is not initialized for the current flow")
         }
         return session
     }
@@ -116,21 +149,21 @@ class DPoPManager {
         switch jwk.keyType {
         case .ellipticCurve:
             guard let curve = jwk.curve?.rawValue, let x = jwk.x, let y = jwk.y else {
-                throw VCIClientException(code: "VCI-011", message: "Incomplete EC JWK for thumbprint")
+                throw DPoPException("Incomplete EC JWK for thumbprint")
             }
             members = ["crv": curve, "kty": jwk.keyType.rawValue, "x": x.base64URLEncodedString(), "y": y.base64URLEncodedString()]
         case .octetKeyPair:
             guard let curve = jwk.curve?.rawValue, let x = jwk.x else {
-                throw VCIClientException(code: "VCI-011", message: "Incomplete OKP JWK for thumbprint")
+                throw DPoPException("Incomplete OKP JWK for thumbprint")
             }
             members = ["crv": curve, "kty": jwk.keyType.rawValue, "x": x.base64URLEncodedString()]
         case .rsa:
             guard let n = jwk.n, let e = jwk.e else {
-                throw VCIClientException(code: "VCI-011", message: "Incomplete RSA JWK for thumbprint")
+                throw DPoPException("Incomplete RSA JWK for thumbprint")
             }
             members = ["e": e.base64URLEncodedString(), "kty": jwk.keyType.rawValue, "n": n.base64URLEncodedString()]
         default:
-            throw VCIClientException(code: "VCI-011", message: "Unsupported JWK type for thumbprint")
+            throw DPoPException("Unsupported JWK type for thumbprint")
         }
         let canonical = try JSONSerialization.data(
             withJSONObject: members,

--- a/Sources/VCIClient/dpop/RSAKeyDER.swift
+++ b/Sources/VCIClient/dpop/RSAKeyDER.swift
@@ -10,8 +10,8 @@ enum RSAKeyDER {
         let bytes = [UInt8](der)
         var cursor = 0
 
-        func fail() -> VCIClientException {
-            VCIClientException(code: "VCI-011", message: "Unable to parse RSA private key DER")
+        func fail() -> DPoPException {
+            DPoPException("Unable to parse RSA private key DER")
         }
 
         func readLength() throws -> Int {

--- a/Sources/VCIClient/exceptions/DPoPException.swift
+++ b/Sources/VCIClient/exceptions/DPoPException.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+class DPoPException: VCIClientException {
+    init(_ message: String?) {
+        super.init(
+            code: "VCI-013",
+            message: message ?? ""
+        )
+    }
+
+    init(
+        message: String?,
+        issuerErrorCode: String? = nil,
+        issuerErrorDescription: String? = nil,
+        cause: Error? = nil
+    ) {
+        super.init(
+            code: "VCI-013",
+            message: message ?? "",
+            issuerErrorCode: issuerErrorCode,
+            issuerErrorDescription: issuerErrorDescription,
+            cause: cause
+        )
+    }
+}

--- a/Tests/VCIClientTests/VCIClientTests.swift
+++ b/Tests/VCIClientTests/VCIClientTests.swift
@@ -183,7 +183,7 @@ final class VCIClientTests: XCTestCase {
     func testGenerateTokenDPoPProof_throwsWhenNoActiveFlow() {
         let client = VCIClient(traceabilityId: "test")
         XCTAssertThrowsError(try client.generateTokenDPoPProof(dpopNonce: "nonce")) { error in
-            XCTAssertEqual((error as? VCIClientException)?.code, "VCI-011")
+            XCTAssertEqual((error as? VCIClientException)?.code, "VCI-013")
         }
     }
 
@@ -223,7 +223,7 @@ final class VCIClientTests: XCTestCase {
         )
 
         XCTAssertThrowsError(try client.generateTokenDPoPProof(dpopNonce: "nonce")) { error in
-            XCTAssertEqual((error as? VCIClientException)?.code, "VCI-011")
+            XCTAssertEqual((error as? VCIClientException)?.code, "VCI-013")
         }
     }
 }

--- a/Tests/VCIClientTests/dpop/DPoPAlgorithmTests.swift
+++ b/Tests/VCIClientTests/dpop/DPoPAlgorithmTests.swift
@@ -39,7 +39,8 @@ final class DPoPAlgorithmTests: XCTestCase {
     func test_throwsWhenOnlyUnsupportedAlgorithmsAdvertised() {
         XCTAssertThrowsError(try DPoPAlgorithm.select(["PS256", "HS256"])) { error in
             let vcierror = error as? VCIClientException
-            XCTAssertEqual(vcierror?.code, "VCI-012")
+            XCTAssertEqual(vcierror?.code, "VCI-013")
+            XCTAssertTrue(vcierror?.message.contains("No supported DPoP algorithm found") ?? false)
         }
     }
 }

--- a/Tests/VCIClientTests/dpop/DPoPManagerTests.swift
+++ b/Tests/VCIClientTests/dpop/DPoPManagerTests.swift
@@ -221,7 +221,13 @@ final class DPoPManagerTests: XCTestCase {
 
     func test_generateProofThrowsWhenNotInitialized() {
         XCTAssertThrowsError(try DPoPManager().generateTokenProof()) { error in
-            XCTAssertEqual((error as? VCIClientException)?.code, "VCI-011")
+            XCTAssertEqual((error as? VCIClientException)?.code, "VCI-013")
+        }
+    }
+
+    func test_jwkThumbprintThrowsWhenNotInitialized() {
+        XCTAssertThrowsError(try DPoPManager().jwkThumbprint()) { error in
+            XCTAssertEqual((error as? VCIClientException)?.code, "VCI-013")
         }
     }
 

--- a/Tests/VCIClientTests/exceptions/VCIClientExceptionTests.swift
+++ b/Tests/VCIClientTests/exceptions/VCIClientExceptionTests.swift
@@ -38,4 +38,25 @@ final class VCIClientExceptionTests: XCTestCase {
         XCTAssertNil(exception.issuerErrorCode)
         XCTAssertNil(exception.issuerErrorDescription)
     }
+
+    func testShouldConstructDpopExceptionWithoutServerDetails() {
+        let exception = DPoPException("DPoP session is not initialized for the current flow")
+
+        XCTAssertEqual("VCI-013", exception.code)
+        XCTAssertNil(exception.issuerErrorCode)
+        XCTAssertNil(exception.issuerErrorDescription)
+        XCTAssertEqual(
+            "DPoP session is not initialized for the current flow",
+            exception.message
+        )
+    }
+
+    func testDpopExceptionRetainsRootCodeWhenWrappingAVciException() {
+        let exception = DPoPException(
+            message: "Failed to sign DPoP proof: key unusable",
+            cause: InvalidPublicKeyException("unsupported curve")
+        )
+
+        XCTAssertEqual("VCI-005", exception.code)
+    }
 }


### PR DESCRIPTION
DPoP failures were reported as `VCI-011` — the interactive-authorization code — and algorithm negotiation as `VCI-012`. Neither identifies a DPoP failure, and both differ from what the Kotlin client reports. Companion to inji/inji-vci-client#161.

## Changes

- Add `DPoPException` (`VCI-013`), following the existing exception structure.
- Throw it from all 10 DPoP failure sites: algorithm negotiation, EC/RSA key generation, RSA key export, RSA public component extraction, private key DER parsing, uninitialized session, JWK thumbprint (EC/OKP/RSA/unsupported).
- Wrap key generation and proof signing, which previously propagated as `VCI-010` "Unknown Exception".

`VCI-012` (`IllegalArgumentException`) is unchanged and stays reserved for argument validation. `VCI-014` remains free for the PAR work in #103.

## Tests

`xcodebuild test -scheme VCIClientTests` — 296 tests, 0 failures. Existing DPoP tests updated to assert VCI-013; added coverage for `DPoPException` construction, root-code resolution, and thumbprint on an uninitialized session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for DPoP key generation, proof signing, validation, and parsing.
  * DPoP-related failures now provide consistent error identification and clearer diagnostic messages.
  * Underlying causes and issuer-provided error details are preserved when available.

* **Tests**
  * Expanded coverage for unsupported algorithms, uninitialized DPoP operations, session resets, and error construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->